### PR TITLE
Fix edit questions bug; Chat Page UI fixes

### DIFF
--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -1369,7 +1369,13 @@ export const Chat = memo(
                 <div
                   key={index}
                   className="w-full rounded-lg border-b-2 border-[rgba(42,42,64,0.4)] hover:cursor-pointer hover:bg-[rgba(42,42,64,0.9)]"
-                  onClick={() => setInputContent(statement)}
+                  onClick={() => {
+                    setInputContent('')  // First clear the input
+                    setTimeout(() => {   // Then set it with a small delay
+                      setInputContent(statement)
+                      textareaRef.current?.focus()
+                    }, 0)
+                  }}
                 >
                   <Button
                     variant="link"

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -548,7 +548,7 @@ export const Chat = memo(
           // console.log('vector_search_rewrite_disabled setting:', courseMetadata?.vector_search_rewrite_disabled)
 
           // Skip query rewrite if disabled in course metadata or if it's the first message
-          if (courseMetadata?.vector_search_rewrite_disabled || (selectedConversation?.messages?.length ?? 0) === 0) {
+          if (courseMetadata?.vector_search_rewrite_disabled || updatedConversation.messages.length <= 1) {
             console.log('Query rewrite disabled for this course or it is the first message, using original query')
             rewrittenQuery = searchQuery
             homeDispatch({ field: 'wasQueryRewritten', value: false })

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -124,8 +124,21 @@ export const ChatInput = ({
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [imageUrls, setImageUrls] = useState<string[]>([])
   const isSmallScreen = useMediaQuery('(max-width: 960px)')
-  // const [showModelSettings, setShowModelSettings] = useState(false);
   const modelSelectContainerRef = useRef<HTMLDivElement | null>(null)
+
+  const handleFocus = () => {
+    setIsFocused(true)
+    if (chatInputParentContainerRef.current) {
+      chatInputParentContainerRef.current.style.boxShadow = `0 0 2px rgba(42,42,120, 1)`
+    }
+  }
+
+  const handleBlur = () => {
+    setIsFocused(false)
+    if (chatInputParentContainerRef.current) {
+      chatInputParentContainerRef.current.style.boxShadow = 'none'
+    }
+  }
 
   const handleTextClick = () => {
     console.log('handleTextClick')
@@ -907,13 +920,21 @@ export const ChatInput = ({
                   `}
             >
               <textarea
-                autoFocus
                 ref={textareaRef}
-                className="m-0 w-full flex-grow resize-none bg-[#070712] p-0 py-2 pr-8 text-black dark:bg-[#070712] dark:text-white md:py-2"
+                className={`chat-input m-0 h-[24px] max-h-[400px] w-full resize-none bg-transparent py-2 pr-8 pl-2 text-white outline-none ${
+                  isFocused ? 'border-blue-500' : ''
+                }`}
+                style={{
+                  resize: 'none',
+                  bottom: `${textareaRef?.current?.scrollHeight}px`,
+                  maxHeight: '400px',
+                  overflow: `${
+                    textareaRef.current && textareaRef.current.scrollHeight > 400
+                      ? 'auto'
+                      : 'hidden'
+                  }`,
+                }}
                 placeholder={
-                  t('Type a message or type "/" to select a prompt...') || ''
-                }
-                aria-label={
                   t('Type a message or type "/" to select a prompt...') || ''
                 }
                 value={content}
@@ -922,14 +943,8 @@ export const ChatInput = ({
                 onCompositionEnd={() => setIsTyping(false)}
                 onChange={handleChange}
                 onKeyDown={handleKeyDown}
-                style={{
-                  resize: 'none',
-                  maxHeight: '400px',
-                  overflow: 'hidden',
-                  outline: 'none', // Add this line to remove the outline from the textarea
-                  paddingTop: '14px',
-                  paddingBottom: '14px',
-                }}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
               />
             </div>
 

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -40,6 +40,7 @@ import utc from 'dayjs/plugin/utc'
 import { montserrat_heading, montserrat_paragraph } from 'fonts'
 import { IntermediateStateAccordion } from '../UIUC-Components/IntermediateStateAccordion'
 import { FeedbackModal } from './FeedbackModal'
+import { saveConversationToServer } from '@/utils/app/conversation'
 
 const useStyles = createStyles((theme) => ({
   imageContainerStyle: {
@@ -292,7 +293,19 @@ export const ChatMessage: FC<Props> = memo(
     const handleEditMessage = () => {
       if (message.content != messageContent) {
         if (selectedConversation && onEdit) {
-          onEdit({ ...message, content: messageContent })
+          const editedMessage = { ...message, content: messageContent }
+          onEdit(editedMessage)
+          
+          // Save to server
+          const updatedConversation = {
+            ...selectedConversation,
+            messages: selectedConversation.messages.map(msg => 
+              msg.id === message.id ? editedMessage : msg
+            )
+          }
+          saveConversationToServer(updatedConversation).catch((error: Error) => {
+            console.error('Error saving edited message to server:', error)
+          })
         }
       }
       setIsEditing(false)

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -730,8 +730,10 @@ export const ChatMessage: FC<Props> = memo(
                         <>{message.content}</>
                       )}
                       <div className="flex w-full flex-col items-start space-y-2">
-                        {/* Query rewrite loading state */}
-                        {isQueryRewriting && (
+                        {/* Query rewrite loading state - only show for current message */}
+                        {isQueryRewriting && 
+                          (messageIndex === (selectedConversation?.messages.length ?? 0) - 1 ||
+                           messageIndex === (selectedConversation?.messages.length ?? 0) - 2) && (
                           <IntermediateStateAccordion
                             accordionKey="query-rewrite"
                             title="Optimizing search query"
@@ -741,26 +743,26 @@ export const ChatMessage: FC<Props> = memo(
                           />
                         )}
 
-                        {/* Query rewrite result - using message properties */}
+                        {/* Query rewrite result - show for any message that was optimized */}
                         {!isQueryRewriting &&
                           message.wasQueryRewritten !== undefined &&
                           message.wasQueryRewritten !== null && (
-                            <IntermediateStateAccordion
-                              accordionKey="query-rewrite-result"
-                              title={
-                                message.wasQueryRewritten
-                                  ? 'Optimized search query'
-                                  : 'No query optimization necessary'
-                              }
-                              isLoading={false}
-                              error={false}
-                              content={
-                                message.wasQueryRewritten
-                                  ? message.queryRewriteText
-                                  : "The LLM determined no optimization was necessary. We only optimize when it's necessary to turn a single message into a stand-alone search to retrieve the best documents."
-                              }
-                            />
-                          )}
+                          <IntermediateStateAccordion
+                            accordionKey="query-rewrite-result"
+                            title={
+                              message.wasQueryRewritten
+                                ? 'Optimized search query'
+                                : 'No query optimization necessary'
+                            }
+                            isLoading={false}
+                            error={false}
+                            content={
+                              message.wasQueryRewritten
+                                ? message.queryRewriteText
+                                : "The LLM determined no optimization was necessary. We only optimize when it's necessary to turn a single message into a stand-alone search to retrieve the best documents."
+                            }
+                          />
+                        )}
 
                         {/* Retrieval results for all messages */}
                         {message.contexts && message.contexts.length > 0 && (

--- a/src/components/Chat/ChatMessage.tsx
+++ b/src/components/Chat/ChatMessage.tsx
@@ -11,6 +11,7 @@ import {
   IconThumbDown,
   IconThumbUpFilled,
   IconThumbDownFilled,
+  IconX,
 } from '@tabler/icons-react'
 import {
   FC,
@@ -277,7 +278,28 @@ export const ChatMessage: FC<Props> = memo(
     }, [message.content, messageIndex, isRunningTool])
 
     const toggleEditing = () => {
+      if (!isEditing) {
+        // Set the initial content when starting to edit
+        if (Array.isArray(message.content)) {
+          const textContent = message.content
+            .filter((content) => content.type === 'text')
+            .map((content) => content.text)
+            .join(' ')
+          setMessageContent(textContent)
+        } else {
+          setMessageContent(message.content as string)
+        }
+      }
       setIsEditing(!isEditing)
+      // Focus the textarea after the state update and component re-render
+      setTimeout(() => {
+        if (!isEditing && textareaRef.current) {
+          textareaRef.current.focus()
+          // Place cursor at the end of the text
+          const length = textareaRef.current.value.length
+          textareaRef.current.setSelectionRange(length, length)
+        }
+      }, 0)
     }
 
     const handleInputChange = (
@@ -291,9 +313,12 @@ export const ChatMessage: FC<Props> = memo(
     }
 
     const handleEditMessage = () => {
-      if (message.content != messageContent) {
+      const trimmedContent = messageContent.trim()
+      if (trimmedContent.length === 0) return
+      
+      if (message.content !== trimmedContent) {
         if (selectedConversation && onEdit) {
-          const editedMessage = { ...message, content: messageContent }
+          const editedMessage = { ...message, content: trimmedContent }
           onEdit(editedMessage)
           
           // Save to server
@@ -343,7 +368,10 @@ export const ChatMessage: FC<Props> = memo(
     const handlePressEnter = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === 'Enter' && !isTyping && !e.shiftKey) {
         e.preventDefault()
-        handleEditMessage()
+        const trimmedContent = messageContent.trim()
+        if (trimmedContent.length > 0) {
+          handleEditMessage()
+        }
       }
     }
 
@@ -594,7 +622,7 @@ export const ChatMessage: FC<Props> = memo(
                   <div className="flex w-full flex-col">
                     <textarea
                       ref={textareaRef}
-                      className="w-full resize-none whitespace-pre-wrap border-none dark:bg-[#343541]"
+                      className="w-full resize-none whitespace-pre-wrap rounded-md border border-gray-300 bg-transparent p-3 focus:border-purple-500 focus:outline-none focus:ring-2 focus:ring-purple-500/20 dark:border-gray-600 dark:bg-[#1E1E3F] dark:focus:border-purple-400"
                       value={messageContent}
                       onChange={handleInputChange}
                       onKeyDown={handlePressEnter}
@@ -604,27 +632,27 @@ export const ChatMessage: FC<Props> = memo(
                         fontFamily: 'inherit',
                         fontSize: 'inherit',
                         lineHeight: 'inherit',
-                        padding: '0',
-                        margin: '0',
-                        overflow: 'hidden',
+                        minHeight: '100px',
                       }}
                     />
-                    <div className="mt-10 flex justify-center space-x-4">
+                    <div className="mt-4 flex justify-end space-x-3">
                       <button
-                        className="h-[40px] rounded-md bg-blue-500 px-4 py-1 text-sm font-medium text-white enabled:hover:bg-blue-600 disabled:opacity-50"
-                        onClick={handleEditMessage}
-                        disabled={messageContent.trim().length <= 0}
-                      >
-                        {t('Save & Submit')}
-                      </button>
-                      <button
-                        className="h-[40px] rounded-md border border-neutral-300 px-4 py-1 text-sm font-medium text-neutral-700 hover:bg-neutral-100 dark:border-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-800"
+                        className="flex items-center gap-2 rounded-md border border-gray-300 bg-transparent px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-100 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
                         onClick={() => {
                           setMessageContent(messageContent)
                           setIsEditing(false)
                         }}
                       >
+                        <IconX size={16} />
                         {t('Cancel')}
+                      </button>
+                      <button
+                        className="flex items-center gap-2 rounded-md bg-purple-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-purple-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-purple-500 dark:hover:bg-purple-600"
+                        onClick={handleEditMessage}
+                        disabled={messageContent.trim().length <= 0}
+                      >
+                        <IconCheck size={16} />
+                        {t('Save & Submit')}
                       </button>
                     </div>
                   </div>

--- a/src/components/Chatbar/Chatbar.tsx
+++ b/src/components/Chatbar/Chatbar.tsx
@@ -223,8 +223,10 @@ export const Chatbar = ({
   }
 
   const handleClearConversations = () => {
-    deleteAllConversationMutation.mutate()
+    homeDispatch({ field: 'conversations', value: [] })
+    chatDispatch({ field: 'searchTerm', value: '' })
     handleNewConversation()
+    deleteAllConversationMutation.mutate()
   }
 
   const handleDeleteConversation = (conversation: Conversation) => {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -71,6 +71,12 @@ const Sidebar = <T,>({
             onClick={() => {
               handleCreateItem()
               handleSearchTerm('')
+              setTimeout(() => {
+                const chatInput = document.querySelector('textarea.chat-input') as HTMLTextAreaElement;
+                if (chatInput) {
+                  chatInput.focus();
+                }
+              }, 100);
             }}
           >
             <IconPlus size={16} />

--- a/src/pages/api/conversation.ts
+++ b/src/pages/api/conversation.ts
@@ -320,30 +320,23 @@ export default async function handler(
         user_email?: string
         course_name?: string
       }
-      console.log(
-        'id: ',
-        id,
-        'userEmail: ',
-        userEmail,
-        'course_name: ',
-        course_name,
-      )
+      
       try {
         if (id) {
-          // Delete conversation
+          // Delete single conversation
           const { data, error } = await supabase
             .from('conversations')
             .delete()
             .eq('id', id)
           if (error) throw error
         } else if (userEmail && course_name) {
-          // Delete all conversations
-          console.log('deleting all conversations')
+          // Delete all conversations that are not in folders
           const { data, error } = await supabase
             .from('conversations')
             .delete()
             .eq('user_email', userEmail)
             .eq('project_name', course_name)
+            .is('folder_id', null)  // Only delete conversations that are not in folders
           if (error) throw error
         } else {
           res.status(400).json({ error: 'Invalid request parameters' })

--- a/src/pages/api/conversation.ts
+++ b/src/pages/api/conversation.ts
@@ -208,10 +208,19 @@ export default async function handler(
 
         if (error) throw error
 
-        // Convert and save messages
+        // First delete all existing messages for this conversation
+        await supabase
+          .from('messages')
+          .delete()
+          .eq('conversation_id', conversation.id)
+
+        // Then insert all messages in their current state
         for (const message of conversation.messages) {
           const dbMessage = convertChatToDBMessage(message, conversation.id)
-          await supabase.from('messages').upsert(dbMessage)
+          const { error: messageError } = await supabase
+            .from('messages')
+            .insert(dbMessage)
+          if (messageError) throw messageError
         }
 
         res.status(200).json({ message: 'Conversation saved successfully' })

--- a/src/pages/api/home/home.tsx
+++ b/src/pages/api/home/home.tsx
@@ -320,6 +320,11 @@ const Home = ({
   }
 
   const handleNewConversation = () => {
+    // If we're already in an empty conversation, don't create a new one
+    if (selectedConversation && selectedConversation.messages.length === 0) {
+      return
+    }
+
     const lastConversation = conversations[conversations.length - 1]
 
     // Determine the model to use for the new conversation
@@ -327,7 +332,7 @@ const Home = ({
 
     const newConversation: Conversation = {
       id: uuidv4(),
-      name: t('New Conversation'),
+      name: '',
       messages: [],
       model: model,
       prompt: DEFAULT_SYSTEM_PROMPT,
@@ -339,17 +344,8 @@ const Home = ({
       updatedAt: new Date().toISOString(),
     }
 
-    const updatedConversations = [newConversation, ...conversations]
-
+    // Only update selectedConversation, don't add to conversations list yet
     dispatch({ field: 'selectedConversation', value: newConversation })
-    dispatch({ field: 'conversations', value: updatedConversations })
-
-    // saveConversation(newConversation)
-    // saveConversations(updatedConversations)
-    // saveConversationToServer(newConversation).catch((error) => {
-    //   console.error('Error saving updated conversation to server:', error)
-    // })
-
     dispatch({ field: 'loading', value: false })
     localStorage.setItem(
       'selectedConversation',


### PR DESCRIPTION
- Corrected a bug where editing a message still saved the old response.  
- Adjusted logic to skip query rewriting when editing the first message.  
- Fixed a query optimization bug where early messages were displayed incorrectly.  
- Set focus to the chat input when starting a new chat.  
- Prevented the creation of sidebar items for new empty chats.  
- Resolved an issue preventing the reuse of the same starter question.  
- Enabled optimistic updates to the chat bar when deleting all conversations.  
- Fixed the "clear conversations" button to exclude clearing conversations in folders.  
- Improved the user interface for editing messages.  