### PR TITLE
Fix Image Inputs on `/chat` page - pass minimal arguments

### DIFF
--- a/src/app/api/chat/openAI/route.ts
+++ b/src/app/api/chat/openAI/route.ts
@@ -28,6 +28,7 @@ export async function POST(req: Request) {
     const { messages } = await req.json()
 
     if (!apiKey || apiKey == 'undefined') {
+      console.debug("KEY IS UNDEFINED, using Vlad's key.")
       apiKey = process.env.VLADS_OPENAI_KEY as string
     }
     if (!apiKey.startsWith('sk')) {
@@ -35,7 +36,7 @@ export async function POST(req: Request) {
         apiKey,
         process.env.NEXT_PUBLIC_SIGNING_KEY as string,
       )) as string
-      console.log('apikey', apiKey)
+      console.debug('apikey', apiKey)
     }
 
     const openai = new OpenAI({

--- a/src/app/api/chat/openaiFunctionCall/route.ts
+++ b/src/app/api/chat/openaiFunctionCall/route.ts
@@ -7,7 +7,7 @@ import type {
 } from 'openai/resources/chat/completions'
 
 import { Conversation } from '~/types/chat'
-import { decrypt, isEncrypted } from '~/utils/crypto'
+import { decrypt, decryptKeyIfNeeded, isEncrypted } from '~/utils/crypto'
 
 export const runtime = 'edge'
 
@@ -46,21 +46,13 @@ export async function POST(req: Request) {
     openaiKey: string
   } = await req.json()
 
-  let decryptedKey = openaiKey
-  // console.log('Decrypted key before transform: ', decryptedKey)
-  if (openaiKey && isEncrypted(openaiKey)) {
-    // Decrypt the key
-    const decryptedText = await decrypt(
-      openaiKey,
-      process.env.NEXT_PUBLIC_SIGNING_KEY as string,
-    )
-    decryptedKey = decryptedText as string
-    // console.log('models.ts Decrypted api key: ', apiKey)
+  let decryptedKey
+  if (openaiKey) {
+    decryptedKey = await decryptKeyIfNeeded(openaiKey) as string
   }
 
-  if (decryptedKey && !decryptedKey.startsWith('sk-')) {
-    // console.log('api key: ', decryptedKey)
-    // console.log('process.env.VLADS_OPENAI_KEY: ', process.env.VLADS_OPENAI_KEY)
+  if (!decryptedKey || !decryptedKey.startsWith('sk-')) {
+    // fallback to Vlad's key
     decryptedKey = process.env.VLADS_OPENAI_KEY as string
   }
   // console.log('Decrypted key: ', decryptedKey)

--- a/src/app/api/chat/openaiFunctionCall/route.ts
+++ b/src/app/api/chat/openaiFunctionCall/route.ts
@@ -7,7 +7,7 @@ import type {
 } from 'openai/resources/chat/completions'
 
 import { Conversation } from '~/types/chat'
-import { decrypt, decryptKeyIfNeeded, isEncrypted } from '~/utils/crypto'
+import { decryptKeyIfNeeded } from '~/utils/crypto'
 
 export const runtime = 'edge'
 
@@ -25,8 +25,6 @@ const conversationToMessages = (
     }
     transformedData.push(simpleMessage)
   })
-
-  // console.log('Transformed messages array: ', transformedData)
 
   return transformedData
 }

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -285,37 +285,10 @@ export const Chat = memo(
             }),
           },
         )
-        const data = await response.json()
+        // const data = await response.json()
         // return data.success
       } catch (error) {
         console.error('Error setting course data:', error)
-        // return false
-      }
-
-      try {
-        // Log conversation to our Flask Backend (especially Nomic)
-        const response = await fetch(
-          `https://flask-production-751b.up.railway.app/onResponseCompletion`,
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              course_name: getCurrentPageName(),
-              conversation: conversation,
-            }),
-          },
-        )
-        const data = await response.json()
-        if (!response.ok) throw new Error(data.message)
-        return data.success
-      } catch (error) {
-        console.error(
-          'Error in chat.tsx running onResponseCompletion():',
-          error,
-        )
-        return false
       }
     }
 
@@ -376,8 +349,8 @@ export const Chat = memo(
             message.contexts = []
             message.content = Array.isArray(message.content)
               ? message.content.filter(
-                  (content) => content.type !== 'tool_image_url',
-                )
+                (content) => content.type !== 'tool_image_url',
+              )
               : message.content
 
             const updatedMessages = [...(selectedConversation.messages || [])]
@@ -573,12 +546,12 @@ export const Chat = memo(
                       .map((msg) => {
                         const contentText = Array.isArray(msg.content)
                           ? msg.content
-                              .filter(
-                                (content) =>
-                                  content.type === 'text' && content.text,
-                              )
-                              .map((content) => content.text!)
-                              .join(' ')
+                            .filter(
+                              (content) =>
+                                content.type === 'text' && content.text,
+                            )
+                            .map((content) => content.text!)
+                            .join(' ')
                           : typeof msg.content === 'string'
                             ? msg.content
                             : ''
@@ -593,12 +566,12 @@ export const Chat = memo(
                       .map((msg) => {
                         const contentText = Array.isArray(msg.content)
                           ? msg.content
-                              .filter(
-                                (content) =>
-                                  content.type === 'text' && content.text,
-                              )
-                              .map((content) => content.text!)
-                              .join(' ')
+                            .filter(
+                              (content) =>
+                                content.type === 'text' && content.text,
+                            )
+                            .map((content) => content.text!)
+                            .join(' ')
                           : typeof msg.content === 'string'
                             ? msg.content
                             : ''
@@ -630,9 +603,9 @@ export const Chat = memo(
                         ? msg.content.trim()
                         : Array.isArray(msg.content)
                           ? msg.content
-                              .map((c) => c.text)
-                              .join(' ')
-                              .trim()
+                            .map((c) => c.text)
+                            .join(' ')
+                            .trim()
                           : '',
                   })),
                 },
@@ -741,7 +714,7 @@ export const Chat = memo(
                 // Check if the response is NO_REWRITE_REQUIRED or if we couldn't extract a valid query
                 if (
                   rewrittenQuery.trim().toUpperCase() ===
-                    'NO_REWRITE_REQUIRED' ||
+                  'NO_REWRITE_REQUIRED' ||
                   !extractedQuery
                 ) {
                   console.log(
@@ -1238,7 +1211,7 @@ export const Chat = memo(
 
         if (imgDescIndex !== -1) {
           // Remove the existing image description
-          ;(currentMessage.content as Content[]).splice(imgDescIndex, 1)
+          ; (currentMessage.content as Content[]).splice(imgDescIndex, 1)
         }
         if (
           selectedConversation?.messages[
@@ -1367,13 +1340,13 @@ export const Chat = memo(
 
     const statements =
       courseMetadata?.example_questions &&
-      courseMetadata.example_questions.length > 0
+        courseMetadata.example_questions.length > 0
         ? courseMetadata.example_questions
         : [
-            'Make a bullet point list of key takeaways from this project.',
-            'What are the best practices for [Activity or Process] in [Context or Field]?',
-            'Can you explain the concept of [Specific Concept] in simple terms?',
-          ]
+          'Make a bullet point list of key takeaways from this project.',
+          'What are the best practices for [Activity or Process] in [Context or Field]?',
+          'Can you explain the concept of [Specific Concept] in simple terms?',
+        ]
 
     // Add this function to create dividers with statements
     const renderIntroductoryStatements = () => {
@@ -1624,8 +1597,8 @@ export const Chat = memo(
                   transition={{ duration: 0.25, ease: 'easeInOut' }}
                 >
                   {selectedConversation &&
-                  selectedConversation.messages &&
-                  selectedConversation.messages?.length === 0 ? (
+                    selectedConversation.messages &&
+                    selectedConversation.messages?.length === 0 ? (
                     <>
                       <div className="mt-16">
                         {renderIntroductoryStatements()}

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -219,10 +219,10 @@ export const ChatInput = ({
           imageUrls.length > 0
             ? imageUrls
             : await Promise.all(
-                imageFiles.map((file) =>
-                  uploadImageAndGetUrl(file, courseName),
-                ),
-              )
+              imageFiles.map((file) =>
+                uploadImageAndGetUrl(file, courseName),
+              ),
+            )
 
         // Construct image content for the message
         imageContent = imageUrlsToUse
@@ -472,18 +472,18 @@ export const ChatInput = ({
   const handleImageUpload = useCallback(
     async (files: File[]) => {
       // TODO: FIX IMAGE UPLOADS ASAP
-      showConfirmationToast({
-        title: `😢 We can't handle all these images...`,
-        message: `Image uploads are temporarily disabled. I'm really sorry, I'm working on getting them back. Email me if you want to complain: kvday2@illinois.edu`,
-        isError: true,
-        autoClose: 10000,
-      })
+      // showConfirmationToast({
+      //   title: `😢 We can't handle all these images...`,
+      //   message: `Image uploads are temporarily disabled. I'm really sorry, I'm working on getting them back. Email me if you want to complain: kvday2@illinois.edu`,
+      //   isError: true,
+      //   autoClose: 10000,
+      // })
 
       // Clear any selected files
       if (imageUploadRef.current) {
         imageUploadRef.current.value = ''
       }
-      return // Exit early to prevent processing
+      // return // Exit early to prevent processing
 
       const validFiles = files.filter((file) => isImageValid(file.name))
       const invalidFilesCount = files.length - validFiles.length
@@ -679,9 +679,8 @@ export const ChatInput = ({
     if (textareaRef && textareaRef.current) {
       textareaRef.current.style.height = 'inherit'
       textareaRef.current.style.height = `${textareaRef.current?.scrollHeight}px`
-      textareaRef.current.style.overflow = `${
-        textareaRef?.current?.scrollHeight > 400 ? 'auto' : 'hidden'
-      }`
+      textareaRef.current.style.overflow = `${textareaRef?.current?.scrollHeight > 400 ? 'auto' : 'hidden'
+        }`
     }
   }, [content])
 
@@ -910,29 +909,26 @@ export const ChatInput = ({
             {/* Button 3: main input text area  */}
             <div
               className={`
-                ${
-                  VisionCapableModels.has(
-                    selectedConversation?.model?.id as OpenAIModelID,
-                  )
-                    ? 'pl-8'
-                    : 'pl-1'
+                ${VisionCapableModels.has(
+                selectedConversation?.model?.id as OpenAIModelID,
+              )
+                  ? 'pl-8'
+                  : 'pl-1'
                 }
                   `}
             >
               <textarea
                 ref={textareaRef}
-                className={`chat-input m-0 h-[24px] max-h-[400px] w-full resize-none bg-transparent py-2 pr-8 pl-2 text-white outline-none ${
-                  isFocused ? 'border-blue-500' : ''
-                }`}
+                className={`chat-input m-0 h-[24px] max-h-[400px] w-full resize-none bg-transparent py-2 pr-8 pl-2 text-white outline-none ${isFocused ? 'border-blue-500' : ''
+                  }`}
                 style={{
                   resize: 'none',
                   bottom: `${textareaRef?.current?.scrollHeight}px`,
                   maxHeight: '400px',
-                  overflow: `${
-                    textareaRef.current && textareaRef.current.scrollHeight > 400
+                  overflow: `${textareaRef.current && textareaRef.current.scrollHeight > 400
                       ? 'auto'
                       : 'hidden'
-                  }`,
+                    }`,
                 }}
                 placeholder={
                   t('Type a message or type "/" to select a prompt...') || ''

--- a/src/pages/api/UIUC-api/fetchImageDescription.ts
+++ b/src/pages/api/UIUC-api/fetchImageDescription.ts
@@ -1,6 +1,6 @@
 // src/pages/api/UIUC-api/fetchImageDescription.ts
 
-import { Conversation, ImageBody } from '@/types/chat'
+import { Content, Conversation, ImageBody } from '@/types/chat'
 import { AllLLMProviders } from '~/utils/modelProviders/LLMProvider'
 
 
@@ -22,11 +22,23 @@ export const fetchImageDescription = async (
   llmProviders: AllLLMProviders,
   controller: AbortController,
 ): Promise<string> => {
+
+  const lastMessageContents =
+    updatedConversation.messages[updatedConversation.messages.length - 1]?.content
+  const contentArray: Content[] = Array.isArray(lastMessageContents)
+    ? lastMessageContents
+    : [
+      {
+        type: 'text',
+        text: lastMessageContents as string,
+      },
+    ]
+
   // Construct the body for the chat API request
   const imageBody: ImageBody = {
-    conversation: updatedConversation,
+    contentArray,
     llmProviders: llmProviders,
-    course_name: course_name,
+    model: updatedConversation.model
   }
 
   try {
@@ -48,8 +60,7 @@ export const fetchImageDescription = async (
 
     // Parse the JSON response and return the image description
     const data = await response.json()
-    console.log('Image description data:', data)
-    return data.choices[0].message.content || ''
+    return data.choices[0].message.content || 'Error: no image description available...'
   } catch (error) {
     // Log the error to the console and abort the fetch request
     console.error('Error fetching image description:', error)

--- a/src/pages/api/imageDescription.ts
+++ b/src/pages/api/imageDescription.ts
@@ -1,30 +1,18 @@
-import { NextResponse } from 'next/server'
+import { NextApiRequest, NextApiResponse } from 'next'
 import { ChatBody, Content, ImageBody, OpenAIChatMessage } from '~/types/chat'
 import { decryptKeyIfNeeded } from '~/utils/crypto'
 
 import { OpenAIError, OpenAIStream } from '@/utils/server'
 
+const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
 
-
-const handler = async (req: Request): Promise<NextResponse> => {
   try {
-    const { conversation, llmProviders, course_name } =
-      (await req.json()) as ImageBody
-
-    // const openAIKey = await decryptKeyIfNeeded(key)
+    const { contentArray, llmProviders, model } = req.body as ImageBody
 
     const systemPrompt = getImageDescriptionSystemPrompt()
-
-    const lastMessageContents =
-      conversation.messages[conversation.messages.length - 1]?.content
-    const contentArray: Content[] = Array.isArray(lastMessageContents)
-      ? lastMessageContents
-      : [
-        {
-          type: 'text',
-          text: lastMessageContents as string,
-        },
-      ]
 
     const messages: OpenAIChatMessage[] = [
       {
@@ -38,37 +26,29 @@ const handler = async (req: Request): Promise<NextResponse> => {
       },
       { role: 'user', content: [...contentArray] },
     ]
-    console.log('Image Description message: ', messages)
 
     const response = await OpenAIStream(
-      conversation.model,
+      model,
       systemPrompt,
-      conversation.temperature,
+      0.1,
       llmProviders,
       messages,
       false,
     )
 
-    return new NextResponse(JSON.stringify(response))
+    return res.status(200).json(response)
   } catch (error) {
     if (error instanceof OpenAIError) {
       const { name, message } = error
       console.error('OpenAI Completion Error', message)
-      const resp = NextResponse.json(
-        {
-          statusCode: 400,
-          name: name,
-          message: message,
-        },
-        { status: 400 },
-      )
-      console.log('Final OpenAIError resp: ', resp)
-      return resp
+      return res.status(400).json({
+        statusCode: 400,
+        name: name,
+        message: message,
+      })
     } else {
       console.error('Unexpected Error', error)
-      const resp = NextResponse.json({ name: 'Error' }, { status: 500 })
-      console.log('Final Error resp: ', resp)
-      return resp
+      return res.status(500).json({ name: 'Error' })
     }
   }
 }

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -125,9 +125,9 @@ export interface ChatBody {
 }
 
 export interface ImageBody {
-  conversation: Conversation
-  course_name: string
+  contentArray: Content[]
   llmProviders: AllLLMProviders
+  model: AnySupportedModel
 }
 
 export interface ChatApiBody {

--- a/src/utils/functionCalling/handleFunctionCalling.ts
+++ b/src/utils/functionCalling/handleFunctionCalling.ts
@@ -45,7 +45,7 @@ export async function handleFunctionCall(
     }
     const openaiFunctionCallResponse = await response.json()
     if (openaiFunctionCallResponse.message === 'No tools invoked by OpenAI') {
-      console.error('No tools invoked by OpenAI')
+      console.debug('No tools invoked by OpenAI')
       return []
     }
 
@@ -342,32 +342,32 @@ export function getOpenAIToolFromUIUCTool(
         description: tool.description,
         parameters: tool.inputParameters
           ? {
-              type: 'object',
-              properties: Object.keys(tool.inputParameters.properties).reduce(
-                (acc, key) => {
-                  const param = tool.inputParameters?.properties[key]
-                  acc[key] = {
-                    type:
-                      param?.type === 'number'
-                        ? 'number'
-                        : param?.type === 'Boolean'
-                          ? 'Boolean'
-                          : 'string',
-                    description: param?.description,
-                    enum: param?.enum,
-                  }
-                  return acc
-                },
-                {} as {
-                  [key: string]: {
-                    type: 'string' | 'number' | 'Boolean'
-                    description?: string
-                    enum?: string[]
-                  }
-                },
-              ),
-              required: tool.inputParameters.required,
-            }
+            type: 'object',
+            properties: Object.keys(tool.inputParameters.properties).reduce(
+              (acc, key) => {
+                const param = tool.inputParameters?.properties[key]
+                acc[key] = {
+                  type:
+                    param?.type === 'number'
+                      ? 'number'
+                      : param?.type === 'Boolean'
+                        ? 'Boolean'
+                        : 'string',
+                  description: param?.description,
+                  enum: param?.enum,
+                }
+                return acc
+              },
+              {} as {
+                [key: string]: {
+                  type: 'string' | 'number' | 'Boolean'
+                  description?: string
+                  enum?: string[]
+                }
+              },
+            ),
+            required: tool.inputParameters.required,
+          }
           : undefined,
       },
     }

--- a/src/utils/server/index.ts
+++ b/src/utils/server/index.ts
@@ -111,8 +111,8 @@ export const OpenAIStream = async (
       }),
       ...(apiType === ProviderNames.OpenAI &&
         OPENAI_ORGANIZATION && {
-          'OpenAI-Organization': OPENAI_ORGANIZATION,
-        }),
+        'OpenAI-Organization': OPENAI_ORGANIZATION,
+      }),
     },
     method: 'POST',
     body: body,
@@ -132,8 +132,7 @@ export const OpenAIStream = async (
       )
     } else {
       throw new Error(
-        `OpenAI API returned an error: ${
-          decoder.decode(result?.value) || result.statusText
+        `OpenAI API returned an error: ${decoder.decode(result?.value) || result.statusText
         }`,
       )
     }

--- a/src/utils/streamProcessing.ts
+++ b/src/utils/streamProcessing.ts
@@ -768,12 +768,12 @@ export async function handleImageContent(
     )
 
     if (imgDescIndex !== -1) {
-      ;(message.content as Content[])[imgDescIndex] = {
+      ; (message.content as Content[])[imgDescIndex] = {
         type: 'text',
         text: `Image description: ${imgDesc}`,
       }
     } else {
-      ;(message.content as Content[]).push({
+      ; (message.content as Content[]).push({
         type: 'text',
         text: `Image description: ${imgDesc}`,
       })


### PR DESCRIPTION
Root cause: Passing the entire `conversation` object is exceeding the 4.5 MB limit on body request size. 
Solution: only pass a single message, not the entire conversation. 