### PR TITLE
Add OpenAI O3-mini support

### DIFF
--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -46,7 +46,10 @@ import ChatUI, {
   WebllmModel,
   webLLMModels,
 } from '~/utils/modelProviders/WebLLM'
-import { selectBestModel, VisionCapableModels } from '~/utils/modelProviders/LLMProvider'
+import {
+  selectBestModel,
+  VisionCapableModels,
+} from '~/utils/modelProviders/LLMProvider'
 import { OpenAIModelID } from '~/utils/modelProviders/types/openai'
 import { UserSettings } from '~/components/Chat/UserSettings'
 import { IconChevronRight } from '@tabler/icons-react'
@@ -96,7 +99,7 @@ export const ChatInput = ({
       messageIsStreaming,
       prompts,
       showModelSettings,
-      llmProviders
+      llmProviders,
     },
 
     dispatch: homeDispatch,
@@ -221,10 +224,10 @@ export const ChatInput = ({
           imageUrls.length > 0
             ? imageUrls
             : await Promise.all(
-              imageFiles.map((file) =>
-                uploadImageAndGetUrl(file, courseName),
-              ),
-            )
+                imageFiles.map((file) =>
+                  uploadImageAndGetUrl(file, courseName),
+                ),
+              )
 
         // Construct image content for the message
         imageContent = imageUrlsToUse
@@ -681,8 +684,9 @@ export const ChatInput = ({
     if (textareaRef && textareaRef.current) {
       textareaRef.current.style.height = 'inherit'
       textareaRef.current.style.height = `${textareaRef.current?.scrollHeight}px`
-      textareaRef.current.style.overflow = `${textareaRef?.current?.scrollHeight > 400 ? 'auto' : 'hidden'
-        }`
+      textareaRef.current.style.overflow = `${
+        textareaRef?.current?.scrollHeight > 400 ? 'auto' : 'hidden'
+      }`
     }
   }, [content])
 
@@ -747,7 +751,10 @@ export const ChatInput = ({
   ): Promise<string> {
     try {
       const uploadedImageUrl = await uploadToS3(file, courseName)
-      const presignedUrl = await fetchPresignedUrl(uploadedImageUrl as string, courseName)
+      const presignedUrl = await fetchPresignedUrl(
+        uploadedImageUrl as string,
+        courseName,
+      )
       return presignedUrl as string
     } catch (error) {
       console.error('Upload failed for file', file.name, error)
@@ -911,26 +918,30 @@ export const ChatInput = ({
             {/* Button 3: main input text area  */}
             <div
               className={`
-                ${VisionCapableModels.has(
-                selectedConversation?.model?.id as OpenAIModelID,
-              )
-                  ? 'pl-8'
-                  : 'pl-1'
+                ${
+                  VisionCapableModels.has(
+                    selectedConversation?.model?.id as OpenAIModelID,
+                  )
+                    ? 'pl-8'
+                    : 'pl-1'
                 }
                   `}
             >
               <textarea
                 ref={textareaRef}
-                className={`chat-input m-0 h-[24px] max-h-[400px] w-full resize-none bg-transparent py-2 pr-8 pl-2 text-white outline-none ${isFocused ? 'border-blue-500' : ''
-                  }`}
+                className={`chat-input m-0 h-[24px] max-h-[400px] w-full resize-none bg-transparent py-2 pl-2 pr-8 text-white outline-none ${
+                  isFocused ? 'border-blue-500' : ''
+                }`}
                 style={{
                   resize: 'none',
                   bottom: `${textareaRef?.current?.scrollHeight}px`,
                   maxHeight: '400px',
-                  overflow: `${textareaRef.current && textareaRef.current.scrollHeight > 400
-                    ? 'auto'
-                    : 'hidden'
-                    }`,
+                  overflow: `${
+                    textareaRef.current &&
+                    textareaRef.current.scrollHeight > 400
+                      ? 'auto'
+                      : 'hidden'
+                  }`,
                 }}
                 placeholder={
                   t('Type a message or type "/" to select a prompt...') || ''
@@ -993,7 +1004,6 @@ export const ChatInput = ({
           <Text
             size={isSmallScreen ? '10px' : 'xs'}
             className={`font-montserratHeading ${montserrat_heading.variable} absolute bottom-2 left-5 break-words rounded-full p-1 text-neutral-400 text-neutral-800 opacity-60 hover:bg-neutral-200 hover:text-neutral-900 dark:bg-opacity-50 dark:text-neutral-100 dark:hover:text-neutral-200`}
-            tt={'capitalize'}
             onClick={handleTextClick}
             style={{ cursor: 'pointer' }}
           >

--- a/src/utils/modelProviders/types/openai.ts
+++ b/src/utils/modelProviders/types/openai.ts
@@ -19,7 +19,10 @@ export interface OpenAIModel {
 }
 
 export enum OpenAIModelID {
-  // GPT_o1 = 'o1-preview', // rolling model
+  // O1 = 'o1', // rolling model - currently points to gpt-3.5-turbo-0125
+  // O1_mini = 'o1-mini', // rolling model - currently points to gpt-3.5-turbo-0125
+  // O3 = 'o3', // rolling model - currently points to gpt-3.5-turbo-0125
+  O3_mini = 'o3-mini', // rolling model - currently points to gpt-3.5-turbo-0125
   GPT_4o_mini = 'gpt-4o-mini', // rolling model - currently points to gpt-4o-2024-05-13
   GPT_4o = 'gpt-4o', // rolling model - currently points to gpt-4o-2024-05-13
   GPT_4 = 'gpt-4', // rolling model - currently points to gpt-4-0613
@@ -36,9 +39,27 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   //   tokenLimit: 128000,
   //   enabled: true,
   // },
+  [OpenAIModelID.O3_mini]: {
+    id: OpenAIModelID.O3_mini,
+    name: 'OpenAI O3-mini (smartest model today)',
+    tokenLimit: 200000,
+    enabled: true,
+  },
+  // [OpenAIModelID.O1_mini]: {
+  //   id: OpenAIModelID.O1_mini,
+  //   name: 'OpenAI O1-mini',
+  //   tokenLimit: 200000,
+  //   enabled: true,
+  // },
+  // [OpenAIModelID.O1]: {
+  //   id: OpenAIModelID.O1,
+  //   name: 'OpenAI O1',
+  //   tokenLimit: 200000,
+  //   enabled: true,
+  // },
   [OpenAIModelID.GPT_4o_mini]: {
     id: OpenAIModelID.GPT_4o_mini,
-    name: 'GPT-4o mini',
+    name: 'GPT-4o mini (best price / performance)',
     tokenLimit: 128000,
     enabled: true,
   },
@@ -50,19 +71,19 @@ export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   },
   [OpenAIModelID.GPT_4_Turbo]: {
     id: OpenAIModelID.GPT_4_Turbo,
-    name: 'GPT-4 Turbo',
+    name: 'GPT-4 Turbo (legacy)',
     tokenLimit: 128000,
     enabled: false,
   },
   [OpenAIModelID.GPT_4]: {
     id: OpenAIModelID.GPT_4,
-    name: 'GPT-4',
+    name: 'GPT-4 (legacy)',
     tokenLimit: 8192,
     enabled: false,
   },
   [OpenAIModelID.GPT_3_5]: {
     id: OpenAIModelID.GPT_3_5,
-    name: 'GPT-3.5',
+    name: 'GPT-3.5 (legacy)',
     tokenLimit: 16385,
     enabled: false,
   },

--- a/src/utils/modelProviders/types/openai.ts
+++ b/src/utils/modelProviders/types/openai.ts
@@ -30,6 +30,10 @@ export enum OpenAIModelID {
   GPT_3_5 = 'gpt-3.5-turbo', // rolling model - currently points to gpt-3.5-turbo-0125
 }
 
+export const ModelIDsThatUseDeveloperMessage: readonly OpenAIModelID[] = [
+  OpenAIModelID.O3_mini,
+] as const
+
 export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   // NOTE: We use these as default values for enabled: true/false.
 

--- a/src/utils/modelProviders/types/openai.ts
+++ b/src/utils/modelProviders/types/openai.ts
@@ -19,10 +19,9 @@ export interface OpenAIModel {
 }
 
 export enum OpenAIModelID {
-  // O1 = 'o1', // rolling model - currently points to gpt-3.5-turbo-0125
-  // O1_mini = 'o1-mini', // rolling model - currently points to gpt-3.5-turbo-0125
-  // O3 = 'o3', // rolling model - currently points to gpt-3.5-turbo-0125
-  O3_mini = 'o3-mini', // rolling model - currently points to gpt-3.5-turbo-0125
+  // We're not going to support o1 series - they are not worth including because replaced by o3.
+  // O3 = 'o3',
+  O3_mini = 'o3-mini', // rolling model
   GPT_4o_mini = 'gpt-4o-mini', // rolling model - currently points to gpt-4o-2024-05-13
   GPT_4o = 'gpt-4o', // rolling model - currently points to gpt-4o-2024-05-13
   GPT_4 = 'gpt-4', // rolling model - currently points to gpt-4-0613
@@ -37,30 +36,12 @@ export const ModelIDsThatUseDeveloperMessage: readonly OpenAIModelID[] = [
 export const OpenAIModels: Record<OpenAIModelID, OpenAIModel> = {
   // NOTE: We use these as default values for enabled: true/false.
 
-  // [OpenAIModelID.GPT_o1]: {
-  //   id: OpenAIModelID.GPT_4o_mini,
-  //   name: 'o1-preview',
-  //   tokenLimit: 128000,
-  //   enabled: true,
-  // },
   [OpenAIModelID.O3_mini]: {
     id: OpenAIModelID.O3_mini,
-    name: 'OpenAI O3-mini (smartest model today)',
+    name: 'OpenAI o3-mini (smartest model today)',
     tokenLimit: 200000,
     enabled: true,
   },
-  // [OpenAIModelID.O1_mini]: {
-  //   id: OpenAIModelID.O1_mini,
-  //   name: 'OpenAI O1-mini',
-  //   tokenLimit: 200000,
-  //   enabled: true,
-  // },
-  // [OpenAIModelID.O1]: {
-  //   id: OpenAIModelID.O1,
-  //   name: 'OpenAI O1',
-  //   tokenLimit: 200000,
-  //   enabled: true,
-  // },
   [OpenAIModelID.GPT_4o_mini]: {
     id: OpenAIModelID.GPT_4o_mini,
     name: 'GPT-4o mini (best price / performance)',

--- a/src/utils/server/index.ts
+++ b/src/utils/server/index.ts
@@ -1,5 +1,7 @@
 import { type OpenAIChatMessage } from '@/types/chat'
 import {
+  ModelIDsThatUseDeveloperMessage,
+  OpenAIModelID,
   OpenAIModels,
   type OpenAIModel,
 } from '~/utils/modelProviders/types/openai'
@@ -97,7 +99,9 @@ export const OpenAIStream = async (
     }
   }
 
-  const isOModel = ['o3', 'o3-mini', 'o1', 'o1-mini'].includes(model.id)
+  const isOModel = ModelIDsThatUseDeveloperMessage.includes(
+    model.id as OpenAIModelID,
+  )
   const body = JSON.stringify({
     ...(OPENAI_API_TYPE === 'openai' && { model: model.id }),
     messages: [

--- a/src/utils/server/index.ts
+++ b/src/utils/server/index.ts
@@ -97,23 +97,25 @@ export const OpenAIStream = async (
     }
   }
 
+  const isOModel = ['o3', 'o3-mini', 'o1', 'o1-mini'].includes(model.id)
   const body = JSON.stringify({
     ...(OPENAI_API_TYPE === 'openai' && { model: model.id }),
     messages: [
       {
-        role: 'system',
+        role: isOModel ? 'developer' : 'system',
         content: systemPrompt,
       },
       ...messages,
     ],
-    max_tokens: 4000,
-    temperature: temperature,
+    ...(isOModel ? {} : { temperature: temperature }),
     stream: stream,
   })
 
   if (!url) {
     throw new Error('URL is undefined')
   }
+
+  console.log("Body that's being sent to the endpoint: ", body)
 
   const res = await fetch(url, {
     headers: {

--- a/src/utils/streamProcessing.ts
+++ b/src/utils/streamProcessing.ts
@@ -64,7 +64,7 @@ export async function processChunkWithStateMachine(
   lastMessage: Message,
   stateMachineContext: { state: State; buffer: string },
   citationLinkCache: Map<number, string>,
-  courseName: string
+  courseName: string,
 ): Promise<string> {
   let { state, buffer } = stateMachineContext
   let processedChunk = ''
@@ -777,12 +777,12 @@ export async function handleImageContent(
     )
 
     if (imgDescIndex !== -1) {
-      ; (message.content as Content[])[imgDescIndex] = {
+      ;(message.content as Content[])[imgDescIndex] = {
         type: 'text',
         text: `Image description: ${imgDesc}`,
       }
     } else {
-      ; (message.content as Content[]).push({
+      ;(message.content as Content[]).push({
         type: 'text',
         text: `Image description: ${imgDesc}`,
       })
@@ -817,7 +817,7 @@ export const routeModelRequest = async (
   controller?: AbortController,
   baseUrl?: string,
 ): Promise<any> => {
-  console.log('In routeModelRequest: ', chatBody, baseUrl)
+  // console.log('In routeModelRequest: ', chatBody, baseUrl)
   /*  Use this to call the LLM. It will call the appropriate endpoint based on the conversation.model.
       🧠 ADD NEW LLM PROVIDERS HERE 🧠
   */


### PR DESCRIPTION
For some reason, o3-mini works but o1 and o1-mini give an unexpected error that `Error in chat route: OpenAIError: Unsupported value: 'messages[0].role' does not support 'developer' with this model.` I get that error with o1 models, so I decided to not support o1 models. They're not worth it anyway. if anyone used them, it would be a mistake. 

But that developer role is the replacement for the `system` role previously used. It's needed by the o3 model, and the docs say it's needed by the o1 models too. But seems to not work. Weird.

It works on my machine!