### PR TITLE
Illinois branding colors

### DIFF
--- a/src/components/UIUC-Components/APIRequestBuilder.tsx
+++ b/src/components/UIUC-Components/APIRequestBuilder.tsx
@@ -161,6 +161,25 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
 });`,
   }
 
+  const styles = {
+    container: {
+      backgroundColor: 'var(--illinois-background-darker)',
+      border: '1px solid var(--illinois-storm-dark)',
+    },
+    input: {
+      backgroundColor: 'var(--illinois-background-dark)',
+      color: 'var(--illinois-white)',
+      border: '1px solid var(--illinois-storm-light)',
+    },
+    button: {
+      backgroundColor: 'var(--illinois-industrial)',
+      color: 'var(--illinois-white)',
+      '&:hover': {
+        backgroundColor: 'var(--illinois-blue)',
+      },
+    },
+  }
+
   return (
     <div className="w-full px-4 sm:px-10">
       <Title

--- a/src/components/UIUC-Components/ApiKeyManagament.tsx
+++ b/src/components/UIUC-Components/ApiKeyManagament.tsx
@@ -582,7 +582,6 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
                     </Button>
                   }
                   rightSectionWidth={'auto'}
-                  styles={styles.input}
                 />
               )}
             </div>

--- a/src/components/UIUC-Components/ApiKeyManagament.tsx
+++ b/src/components/UIUC-Components/ApiKeyManagament.tsx
@@ -287,6 +287,21 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
     }
   }
 
+  const styles = {
+    input: {
+      border: '1px solid var(--illinois-storm-light)',
+      backgroundColor: 'var(--illinois-background-dark)',
+      color: 'var(--illinois-white)',
+    },
+    button: {
+      backgroundColor: 'var(--illinois-orange)',
+      color: 'var(--illinois-white)',
+      '&:hover': {
+        backgroundColor: 'var(--illinois-altgeld)',
+      },
+    },
+  }
+
   return (
     <Card
       shadow="xs"
@@ -567,20 +582,7 @@ axios.post('${baseUrl}/api/chat-api/chat', data, {
                     </Button>
                   }
                   rightSectionWidth={'auto'}
-                  styles={{
-                    input: {
-                      backgroundColor: '#1a1b3e',
-                      paddingRight: '90px',
-                      textOverflow: 'ellipsis',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      fontFamily: `var(--font-montserratParagraph), ${theme.fontFamily}`,
-                      borderColor: '#4a4b6a',
-                      '&:focus': {
-                        borderColor: '#6e56cf',
-                      },
-                    },
-                  }}
+                  styles={styles.input}
                 />
               )}
             </div>

--- a/src/components/UIUC-Components/navbars/GlobalHeader.tsx
+++ b/src/components/UIUC-Components/navbars/GlobalHeader.tsx
@@ -13,18 +13,18 @@ import { IconClipboardText, IconFile } from '@tabler/icons-react'
 export default function Header({ isNavbar = false }: { isNavbar?: boolean }) {
   const headerStyle = isNavbar
     ? {
-        backgroundColor: '#15162c',
-        display: 'flex',
-        justifyContent: 'flex-end',
-        padding: '0.2em 0.2em',
-        paddingRight: '0.3em',
-      }
+      backgroundColor: 'var(--illinois-blue)',  
+      display: 'flex',
+      justifyContent: 'flex-end',
+      padding: '0.2em 0.2em',
+      paddingRight: '0.3em',
+    }
     : {
-        backgroundColor: '#2e026d',
-        display: 'flex',
-        justifyContent: 'flex-end',
-        padding: '1em',
-      }
+      backgroundImage: 'var(--illinois-blue)',  
+      display: 'flex',
+      justifyContent: 'flex-end',
+      padding: '1em',
+    }
 
   const clerk_obj = useUser()
   const posthog = usePostHog()
@@ -114,17 +114,18 @@ export function LandingPageHeader({
   const { classes, theme } = useStyles()
   const headerStyle = forGeneralPurposeNotLandingpage
     ? {
-        backgroundColor: '#2e026d',
-        display: 'flex',
-        justifyContent: 'flex-end',
-        padding: '2em 2em',
-      }
+      backgroundColor: 'var(--illinois-blue)',  
+      display: 'flex',
+      justifyContent: 'flex-end',
+      padding: '0.2em 0.2em',
+      paddingRight: '0.3em',
+    }
     : {
-        backgroundColor: '#2e026d',
-        display: 'flex',
-        justifyContent: 'flex-end',
-        padding: '1em',
-      }
+      backgroundColor: 'var(--illinois-blue)',  
+      display: 'flex',
+      justifyContent: 'flex-end',
+      padding: '1em',
+    }
 
   const clerk_obj = useUser()
   const [userEmail, setUserEmail] = useState('no_email')
@@ -305,29 +306,26 @@ const useStyles = createStyles((theme) => ({
     },
   },
   link: {
-    // textTransform: 'uppercase',
     fontSize: rem(13),
-    color: '#f1f5f9',
+    color: 'var(--illinois-white)',  
     padding: `${theme.spacing.sm} ${theme.spacing.xs}`,
-    // margin: '0.35rem',
     fontWeight: 700,
-    transition:
-      'border-color 100ms ease, color 100ms ease, background-color 100ms ease',
-    borderRadius: theme.radius.sm, // added to make the square edges round
+    transition: 'border-color 100ms ease, color 100ms ease, background-color 100ms ease',
+    borderRadius: theme.radius.sm,
 
     '&:hover': {
-      color: 'hsl(280,100%,70%)', // make the hovered color lighter
+      color: 'var(--illinois-industrial)',  
       backgroundColor: 'rgba(255, 255, 255, 0.1)',
       textDecoration: 'none',
       borderRadius: '10px',
     },
     '&[data-active="true"]': {
-      color: 'hsl(280,100%,70%)',
-      borderBottom: '2px solid hsl(280,100%,70%)', // make the bottom border of the square thicker and same color as "AI"
-      textDecoration: 'none', // remove underline
-      borderRadius: '10px', // added to make the square edges round when hovered
-      backgroundColor: 'rgba(255, 255, 255, 0.1)', // add a background color when the link is active
-      textAlign: 'right', // align the text to the right
+      color: 'var(--illinois-industrial)',  
+      borderBottom: '2px solid var(--illinois-industrial)',  
+      textDecoration: 'none',
+      borderRadius: '10px',
+      backgroundColor: 'rgba(255, 255, 255, 0.1)',
+      textAlign: 'right',
     },
   },
 }))

--- a/src/pages/[course_name]/api.tsx
+++ b/src/pages/[course_name]/api.tsx
@@ -83,6 +83,16 @@ const ApiPage: NextPage = () => {
     return <></>
   }
 
+  const styles = {
+    container: {
+      backgroundColor: 'var(--illinois-background-dark)',
+      color: 'var(--illinois-white)',
+    },
+    header: {
+      borderBottom: '1px solid var(--illinois-storm-light)',
+    },
+  };
+
   return (
     <>
       <Navbar course_name={router.query.course_name as string} />

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -105,24 +105,22 @@ const MyApp: AppType = ({ Component, pageProps: { ...pageProps } }) => {
                 theme={{
                   colorScheme: 'dark',
                   colors: {
-                    // Add your color
-                    deepBlue: ['#E9EDFC', '#C1CCF6', '#99ABF0' /* ... */],
-                    lime: ['#a3e635', '#65a30d', '#365314' /* ... */],
-                    aiPurple: ['#C06BF9'],
-                    backgroundColors: ['#2e026d', '#020307'],
-                    nearlyBlack: ['#0E1116'],
-                    nearlyWhite: ['#F7F7F7'],
-                    disabled: ['#2A2F36'],
-                    errorBackground: ['#dc2626'],
-                    errorBorder: ['#dc2626'],
+                    // Using CSS variables for colors
+                    deepBlue: ['var(--illinois-blue)'],
+                    primary: ['var(--illinois-orange)'],
+                    secondary: ['var(--illinois-blue)'],
+                    accent: ['var(--illinois-industrial)'],
+                    background: ['var(--illinois-background-dark)'],
+                    nearlyBlack: ['var(--illinois-background-darker)'],
+                    nearlyWhite: ['var(--illinois-white)'],
+                    disabled: ['var(--illinois-storm-dark)'],
+                    errorBackground: ['var(--illinois-berry)'],
+                    errorBorder: ['var(--illinois-berry)'],
                   },
-                  // primaryColor: 'aiPurple',
-
                   shadows: {
                     // md: '1px 1px 3px rgba(0, 0, 0, .25)',
                     // xl: '5px 5px 3px rgba(0, 0, 0, .25)',
                   },
-
                   headings: {
                     fontFamily: 'Montserrat, Roboto, sans-serif',
                     sizes: {
@@ -131,8 +129,8 @@ const MyApp: AppType = ({ Component, pageProps: { ...pageProps } }) => {
                     },
                   },
                   defaultGradient: {
-                    from: '#dc2626',
-                    to: '#431407',
+                    from: 'var(--illinois-berry)',
+                    to: 'var(--illinois-earth)',
                     deg: 80,
                   },
                 }}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -34,22 +34,25 @@ const Home: NextPage = () => {
 
       <LandingPageHeader />
 
-      <main className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-[#2e026d] to-[#0E1116]">
+      <main className="flex min-h-screen flex-col items-center justify-center illinois-blue-gradient-bg">
         <div className="container flex w-full max-w-[95vw] flex-col items-center justify-center gap-4 px-4 py-8">
           <h1 className="text-5xl font-extrabold tracking-tight text-white sm:text-[5rem]">
-            UIUC.<span className="text-[hsl(280,100%,70%)]">chat</span>
+            UIUC.<span className="text-[var(--illinois-orange)]">chat</span>
           </h1>
           <div className="w-full max-w-4xl">
             {/* size="lg"
             py="l"
             style={{ position: 'relative', minHeight: '100%' }} */}
             <Title
-              color="#57534e"
+              color="var(--illinois-storm-dark)"
               order={2}
               variant="gradient"
               weight={800}
-              // gradient={{ from: 'indigo', to: 'cyan', deg: 45 }}
-              gradient={{ from: 'pink', to: 'blue', deg: 45 }}
+              gradient={{
+                from: 'var(--illinois-orange)',
+                to: 'var(--illinois-industrial)',
+                deg: 45
+              }}
               ta="center"
               mt="md"
             >
@@ -83,12 +86,12 @@ const Home: NextPage = () => {
           <h4 className="font-extrabold tracking-tight text-white sm:text-[3rem]">
             <div>
               Some background{' '}
-              <span className="text-[hsl(280,100%,70%)]">about us</span>
+              <span className="text-[var(--illinois-orange)]">about us</span>
             </div>
           </h4>
           <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:gap-8">
             <Link
-              className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 text-white hover:bg-white/20"
+              className="flex max-w-xs flex-col gap-4 rounded-xl bg-[var(--illinois-white)]/10 p-4 text-[var(--illinois-white)] hover:bg-[var(--illinois-white)]/20"
               href="https://github.com/kastanday/ai-ta-frontend"
               target="_blank"
             >
@@ -99,7 +102,7 @@ const Home: NextPage = () => {
               </div>
             </Link>
             <Link
-              className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 text-white hover:bg-white/20"
+              className="flex max-w-xs flex-col gap-4 rounded-xl bg-[var(--illinois-white)]/10 p-4 text-[var(--illinois-white)] hover:bg-[var(--illinois-white)]/20"
               href="https://ai.ncsa.illinois.edu/"
               target="_blank"
             >
@@ -111,7 +114,7 @@ const Home: NextPage = () => {
               </div>
             </Link>
             <Link
-              className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 text-white hover:bg-white/20"
+              className="flex max-w-xs flex-col gap-4 rounded-xl bg-[var(--illinois-white)]/10 p-4 text-[var(--illinois-white)] hover:bg-[var(--illinois-white)]/20"
               href="https://kastanday.com/"
               target="_blank"
             >
@@ -123,7 +126,7 @@ const Home: NextPage = () => {
             </Link>
 
             <Link
-              className="flex max-w-xs flex-col gap-4 rounded-xl bg-white/10 p-4 text-white hover:bg-white/20"
+              className="flex max-w-xs flex-col gap-4 rounded-xl bg-[var(--illinois-white)]/10 p-4 text-[var(--illinois-white)] hover:bg-[var(--illinois-white)]/20"
               href="https://status.uiuc.chat/"
               target="_blank"
             >
@@ -199,7 +202,7 @@ const useStyles = createStyles((theme) => ({
     '&::after': {
       content: '""',
       display: 'block',
-      backgroundColor: 'white', //theme.fn.primaryColor(),
+      backgroundColor: 'var(--illinois-white)',
       width: rem(45),
       height: rem(2),
       marginTop: theme.spacing.sm,
@@ -209,16 +212,14 @@ const useStyles = createStyles((theme) => ({
   },
 
   card: {
-    border: `${rem(1)} solid ${
-      theme.colorScheme === 'dark' ? theme.colors.dark[5] : theme.colors.gray[1]
-    }`,
+    border: `${rem(1)} solid var(--illinois-storm-light)`,
   },
 
   cardTitle: {
     '&::after': {
       content: '""',
       display: 'block',
-      backgroundColor: 'white', //theme.fn.primaryColor(),
+      backgroundColor: 'var(--illinois-white)',
       width: rem(45),
       height: rem(2),
       marginTop: theme.spacing.sm,
@@ -230,7 +231,7 @@ export function FeaturesCards() {
   const { classes, theme } = useStyles()
   const features = mockdata.map((feature) => (
     <Card
-      bg="#0E1116"
+      bg="var(--illinois-background-darker)"
       key={feature.title}
       shadow="md"
       radius="md"
@@ -238,9 +239,9 @@ export function FeaturesCards() {
       padding="xl"
       style={{ position: 'relative', minHeight: '100%' }}
     >
-      <feature.icon size={rem(50)} stroke={2} color="#C06BF9" />
+      <feature.icon size={rem(50)} stroke={2} color="var(--illinois-orange)" />
       <Text
-        color="white"
+        color="var(--illinois-white)"
         fz="lg"
         fw={500}
         className={classes.cardTitle}
@@ -248,7 +249,7 @@ export function FeaturesCards() {
       >
         {feature.title}
       </Text>
-      <Text style={{ color: 'white' }} fz="sm" c="dimmed" mt="sm">
+      <Text style={{ color: 'var(--illinois-white)' }} fz="sm" c="dimmed" mt="sm">
         {feature.description}
       </Text>
     </Card>
@@ -343,10 +344,10 @@ function CourseCard() {
       {cards.map((card) => (
         <div
           key={card.course_slug}
-          className="box-sizing: border-box; border: 100px solid #ccc;"
+          className="box-sizing: border-box; border: 100px solid var(--illinois-storm-light);"
         >
           <Card
-            bg="#0E1116"
+            bg="var(--illinois-background-darker)"
             style={{
               width: '80vw',
               height: 'auto',
@@ -383,7 +384,7 @@ function CourseCard() {
                 >
                   {card.title}
                 </Text>
-                <Badge size="xl" color="pink" variant="light">
+                <Badge size="xl" color="var(--illinois-orange)" variant="light">
                   {card.badge}
                 </Badge>
               </Group>
@@ -393,7 +394,7 @@ function CourseCard() {
                   dangerouslySetInnerHTML={{
                     __html: card.description.replace(
                       /<a/g,
-                      '<a style="color: lightblue; text-decoration: underline;"',
+                      '<a style="color: var(--illinois-arches); text-decoration: underline;"',
                     ),
                   }}
                 />
@@ -402,7 +403,10 @@ function CourseCard() {
               <Link href={`/${card.course_slug}/chat`}>
                 <Button
                   variant="light"
-                  color="blue"
+                  style={{
+                    backgroundColor: 'var(--illinois-industrial)',
+                    color: 'var(--illinois-white)',
+                  }}
                   fullWidth
                   mt="md"
                   radius="md"

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -8,6 +8,101 @@
   grid-template: auto / repeat(3, 1fr);
 } */
 
+:root {
+  /* Primary Colors */
+  --illinois-orange: #FF5F05;
+  --illinois-blue: #13294B;
+  
+  /* Secondary Colors (Storm) */
+  --illinois-storm-dark: #707372;
+  --illinois-storm-medium: #9C9A9D;
+  --illinois-storm-light: #C8C6C7;
+  --illinois-white: #FFFFFF;
+  --illinois-black: #000000;
+
+  /* Supporting Colors */
+  --illinois-industrial: #1D58A7;
+  --illinois-arches: #009FD4;
+  --illinois-patina: #007E8E;
+  --illinois-berry: #5C0E41;
+  --illinois-harvest: #FCB316;
+  --illinois-prairie: #006230;
+  --illinois-earth: #7D3E13;
+  
+  /* Accessibility Colors */
+  --illinois-altgeld: #C84113;
+
+  /* Background Colors */
+  --illinois-storm-95: #F4F4F4;
+  --illinois-storm-10: #252525;
+
+  /* Existing variables mapped to UIUC colors */
+  --background: var(--illinois-white);
+  --foreground: var(--illinois-storm-10);
+  
+  --primary: var(--illinois-orange);
+  --primary-foreground: var(--illinois-white);
+  
+  --secondary: var(--illinois-blue);
+  --secondary-foreground: var(--illinois-white);
+
+  --muted: var(--illinois-storm-95);
+  --muted-foreground: var(--illinois-storm-dark);
+
+  --accent: var(--illinois-industrial);
+  --accent-foreground: var(--illinois-white);
+
+  --destructive: var(--illinois-berry);
+  --destructive-foreground: var(--illinois-white);
+
+  --border: var(--illinois-storm-light);
+  --input: var(--illinois-storm-light);
+  --ring: var(--illinois-blue);
+
+  --radius: 0.5rem;
+
+  /* Additional UI Colors */
+  --illinois-background-dark: #202123;
+  --illinois-background-darker: #0e1116;
+  --illinois-purple: #2e026d;
+  --illinois-purple-dark: #15162c;
+  --illinois-link: #4a4ae8;
+  --illinois-scrollbar-hover: #807f7f;
+  --illinois-gold: #ffd700;
+  --illinois-purple-light: #9d4edd;
+
+  
+  /* Gradients */
+  --illinois-blue-gradient: linear-gradient(to top, #1d58a7, #13294b);
+  --illinois-orange-gradient: linear-gradient(to top, #fcb316, #ff5f05);
+}
+.illinois-blue-gradient-bg {
+  background-image: var(--illinois-blue-gradient);
+}
+.dark {
+  --background: var(--illinois-blue);
+  --foreground: var(--illinois-white);
+
+  --primary: var(--illinois-orange);
+  --primary-foreground: var(--illinois-blue);
+
+  --secondary: var(--illinois-storm-dark);
+  --secondary-foreground: var(--illinois-white);
+
+  --muted: var(--illinois-storm-10);
+  --muted-foreground: var(--illinois-storm-light);
+
+  --accent: var(--illinois-industrial);
+  --accent-foreground: var(--illinois-white);
+
+  --destructive: var(--illinois-berry);
+  --destructive-foreground: var(--illinois-white);
+
+  --border: var(--illinois-storm-dark);
+  --input: var(--illinois-storm-dark);
+  --ring: var(--illinois-orange);
+}
+
 /* Force dark mode for all users!! */
 @media (prefers-color-scheme: dark) {
   html {
@@ -48,7 +143,7 @@
 }
 
 html {
-  background: #202123;
+  background: var(--illinois-background-dark);
 }
 
 @media (max-width: 720px) {
@@ -87,15 +182,13 @@ pre:has(div.codeblock) {
 /* Make the purple background fade out  */
 .course-page-main {
   /* height: 400px;     */
-  background: -webkit-gradient(
-    linear,
-    left top,
-    left bottom,
-    from(#2e026d),
-    to(#020307),
-    color-stop(0.75, #15162c)
-  );
-  background-color: #020307;
+  background: -webkit-gradient(linear,
+      left top,
+      left bottom,
+      from(var(--illinois-purple)),
+      to(var(--illinois-background-darker)),
+      color-stop(0.75, var(--illinois-purple-dark)));
+  background-color: var(--illinois-background-darker);
   background-size:
     100% 45%,
     0%;
@@ -128,7 +221,7 @@ pre:has(div.codeblock) {
   right: 0;
   width: 40%;
   height: 1.2em;
-  background: linear-gradient(to right, rgba(255, 255, 255, 0), #0e1116 90%);
+  background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--illinois-background-darker) 90%);
 }
 
 .fade-3-lines::after {
@@ -139,7 +232,7 @@ pre:has(div.codeblock) {
   right: 0;
   width: 40%;
   height: 1.2em;
-  background: linear-gradient(to right, rgba(255, 255, 255, 0), #0e1116 90%);
+  background: linear-gradient(to right, rgba(255, 255, 255, 0), var(--illinois-background-darker) 90%);
 }
 
 /* Standard list properties. Didn't work before manually adding this. */
@@ -159,7 +252,7 @@ li {
 
 .kas-gradient-text {
   background-color: #f3ec78;
-  background-image: linear-gradient(45deg, #f3ec78, #af4261);
+  background-image: var(--illinois-warm-gradient);
   background-size: 100%;
   -webkit-background-clip: text;
   -moz-background-clip: text;
@@ -185,7 +278,7 @@ li {
 }
 
 .tag-item {
-  background-color: #020307;
+  background-color: var(--illinois-background-darker);
   display: inline-block;
   font-size: 16px;
   border-radius: 30px;
@@ -197,7 +290,7 @@ li {
 }
 
 .tag-item button {
-  background-color: blueviolet;
+  background-color: var(--illinois-blueviolet);
   width: 22px;
   height: 22px;
   border-radius: 50%;
@@ -218,7 +311,7 @@ li {
 
 .goldUnderline {
   text-decoration: underline;
-  text-decoration-color: gold;
+  text-decoration-color: var(--illinois-gold);
   color: inherit;
 }
 
@@ -248,7 +341,7 @@ li {
   position: relative;
   overflow: hidden;
   /* background-color: #020307; */
-  background-color: #070712;
+  background-color: var(--illinois-blue);
 }
 
 .skeleton-box::after {
@@ -258,13 +351,16 @@ li {
   bottom: 0;
   left: 0;
   transform: translateX(-100%);
-  background-image: linear-gradient(
-    90deg,
-    rgba(99, 39, 175, 0) 0,
-    rgba(75, 85, 72, 0.2) 20%,
-    rgba(30, 64, 175, 0.5) 60%,
-    rgba(66, 1, 95, 0)
-  );
+  background-image: linear-gradient(90deg,
+      rgba(19, 41, 75, 0),
+      /* illinois-blue */
+      rgba(112, 115, 114, 0.2),
+      /* illinois-storm-dark */
+      rgba(29, 88, 167, 0.5),
+      /* illinois-industrial */
+      rgba(92, 14, 65, 0)
+      /* illinois-berry */
+    );
   /* Changed the primary color to purple-900 */
   animation: shimmer 5s infinite;
   content: '';
@@ -284,31 +380,31 @@ li {
   /* For vertical scrollbars */
   height: 6px;
   /* For horizontal scrollbars */
-  background-color: #202134;
+  background-color: var(--illinois-storm-dark);
 }
 
 ::-webkit-scrollbar-corner {
-  background-color: #070711;
+  background-color: var(--illinois-blue);
 }
 
 ::-webkit-scrollbar-thumb {
-  background-color: #ccc;
+  background-color: var(--illinois-storm-medium);
   border-radius: 10px;
 }
 
 /* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
-  background-color: #807f7f;
+  background-color: var(--illinois-scrollbar-hover);
   border-radius: 4px;
 }
 
 @keyframes pulsate {
   0% {
-    color: #ffffff;
+    color: var(--illinois-white);
   }
 
   100% {
-    color: #9d4edd;
+    color: var(--illinois-purple-light);
   }
 }
 
@@ -330,8 +426,8 @@ a[data-footnote-backref] {
   border-radius: 50%;
   font-size: 75%;
   line-height: 1;
-  color: #4a4ae8;
-  background-color: #2d2d2d;
+  color: var(--illinois-industrial);
+  background-color: var(--illinois-storm-dark);
   margin-right: 4px;
   padding: 2px 4px;
   border: none;
@@ -340,13 +436,13 @@ a[data-footnote-backref] {
 
 /* Styling for visited citation links */
 .supMarkdown a:visited {
-  color: rgb(173, 92, 227);
+  color: var(--illinois-berry);
 }
 
 .supMarkdown a:hover,
 .supMarkdown a:focus {
-  background-color: blueviolet;
-  color: #ffffff;
+  background-color: var(--illinois-industrial);
+  color: var(--illinois-white);
   cursor: pointer;
 }
 
@@ -356,6 +452,8 @@ a[data-footnote-backref] {
     /* Smaller font size on smaller screens */
     padding: 5px 10px;
     /* Adjust padding to ensure text doesn't overlap */
+    color: var(--illinois-industrial);
+    background-color: var(--illinois-blue);
   }
 }
 
@@ -374,8 +472,8 @@ a[data-footnote-backref] {
   font-size: 1rem;
   /* Adjust font size to fit the buttons */
   padding: 10px 10px;
-  color: #4a4ae8;
-  background-color: #15162c;
+  color: var(--illinois-link);
+  background-color: var(--illinois-purple-dark);
   border-radius: 5px;
   border: none;
   text-decoration: none;
@@ -395,8 +493,8 @@ a[data-footnote-backref] {
 /* Hover and focus states for document buttons */
 .linkMarkDown button:not(.codeblock-button):hover,
 .linkMarkDown button:not(.codeblock-button):focus {
-  background-color: blueviolet;
-  color: #ffffff;
+  background-color: var(--illinois-blueviolet);
+  color: var(--illinois-white);
   cursor: pointer;
 }
 
@@ -407,7 +505,7 @@ a[data-footnote-backref] {
 
 /* Visited state for document buttons */
 .linkMarkDown button:not(.codeblock-button):visited {
-  color: rgb(173, 92, 227);
+  color: var(--illinois-berry);
 }
 
 .linkMarkDown ol:has(> li > button) {
@@ -420,7 +518,7 @@ a[data-footnote-backref] {
   /* Padding inside the card */
   margin: 20px 0;
   /* Margin around the card */
-  background-color: #1e1e2f;
+  background-color: var(--illinois-purple-dark);
   /* Slightly lighter than the button background for contrast */
   border-radius: 10px;
   /* Rounded corners for the card */
@@ -443,7 +541,7 @@ a[data-footnote-backref] {
 }
 
 .codeBlock pre:has(> code) {
-  background-color: #101122 !important;
+  background-color: var(--illinois-purple-dark) !important;
 }
 
 /* Style for individual list items */
@@ -464,15 +562,15 @@ a[data-footnote-backref] {
 /* For styling MagicBell. We hide the logo, but keep the CTA button.  */
 /* `EnablePushNotificationsButton` works on localhost, `css-s37qmw` works on production. */
 body button[class$='EnablePushNotificationsButton'] {
-  background-color: #f8fafc !important;
-  color: #15162c !important;
+  background-color: var(--illinois-storm-95) !important;
+  color: var(--illinois-purple-dark) !important;
 }
 
 /* padding: 10px !important; */
 /* border-radius: 4px !important; */
 button.css-s37qmw {
-  background: #f8fafc !important;
-  color: #15162c !important;
+  background: var(--illinois-storm-95) !important;
+  color: var(--illinois-purple-dark) !important;
 }
 
 /* Remove branded footer from MagicBell (only works on prod w/ compiled css) */
@@ -490,6 +588,7 @@ button.css-s37qmw {
   from {
     --r: 0deg;
   }
+
   to {
     --r: 360deg;
   }


### PR DESCRIPTION
added illinois theme colors to the globals.css and implemented in homepage and navbar:
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/47f3dbd9-a87f-4df5-b8da-c626d82628bc" />

Notes: dark mode is currently enabled by default. Here are all the places where theme variables were/are hardcoded prior to the PR. Ideally we centralize all these colors in one place so it's easier to stay compliant with University Style guidelines. 

1. Theme variables are set when the mantine provider is initialized: [src/pages/_app.tsx](https://github.com/CAII-NCSA/uiuc-chat-frontend/blob/main/src/pages/_app.tsx#L102)
2. In `useStyles` statements [src/components/UIUC-Components/navbars/Navbar.tsx](https://github.com/CAII-NCSA/uiuc-chat-frontend/blob/f1e1f73ea1cc43b880be8c43fb13c1b55f95c158/src/components/UIUC-Components/navbars/Navbar.tsx#L53). This is present in many files so you will probably need to do a repo-level search to find these occurences. 
3. As a Mantine ClassName: [src/components/UIUC-Components/navbars/Navbar.tsx](https://github.com/CAII-NCSA/uiuc-chat-frontend/blob/f1e1f73ea1cc43b880be8c43fb13c1b55f95c158/src/components/UIUC-Components/navbars/Navbar.tsx#L430). This is also present in many of the files and I'm sharing an example of what that looks like here. This will probably be the hardest to track down and find and replace easily. 

[Mantine docs](https://mantine.dev/styles/styles-api/) are a good reference to understand how this differs from normal CSS classes. The bottom of this [Illinois Brand Colors Page](https://brand.illinois.edu/visual-identity/color) outlines what colors should be used with the background color we choose. 