### PR TITLE
Robust error handling on `/chat` page. Errors are propogated properly from LLM providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,11 @@
       "name": "uiuc-chat-frontend",
       "version": "0.1.0",
       "dependencies": {
-        "@ai-sdk/amazon-bedrock": "1.0.7",
-        "@ai-sdk/anthropic": "^1.1.10",
-        "@ai-sdk/google": "1.0.7",
+        "@ai-sdk/amazon-bedrock": "^1.0.7",
+        "@ai-sdk/anthropic": "^1.1.15",
+        "@ai-sdk/google": "^1.0.7",
         "@ai-sdk/openai": "^0.0.34",
-        "@ai-sdk/provider": "1.0.7",
+        "@ai-sdk/provider": "^1.0.7",
         "@aws-sdk/client-bedrock-runtime": "^3.751.0",
         "@aws-sdk/client-s3": "3.338.0",
         "@aws-sdk/s3-presigned-post": "3.338.0",
@@ -213,12 +213,12 @@
       }
     },
     "node_modules/@ai-sdk/anthropic": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.1.10.tgz",
-      "integrity": "sha512-kWmqr4ONAify8APPp+dVlw2X79ygUqPxLnA8buXrt1Sv+tkWUQ4bfTrfAkaavDJ4/VPODWqRyKcYADD482TtKg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-1.1.15.tgz",
+      "integrity": "sha512-KqI2vjEPLieBmZh+QIB0055JGUh9F7QcMdqj+dOGrtBawd0zjhZ2uBxP8Ghvl4WhbuTEOo54mlAg7RZO0eP2Tg==",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "@ai-sdk/provider-utils": "2.1.10"
+        "@ai-sdk/provider": "1.0.10",
+        "@ai-sdk/provider-utils": "2.1.11"
       },
       "engines": {
         "node": ">=18"
@@ -228,9 +228,9 @@
       }
     },
     "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.9.tgz",
-      "integrity": "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.10.tgz",
+      "integrity": "sha512-pco8Zl9U0xwXI+nCLc0woMtxbvjU8hRmGTseAUiPHFLYAAL8trRPCukg69IDeinOvIeo1SmXxAIdWWPZOLb4Cg==",
       "dependencies": {
         "json-schema": "^0.4.0"
       },
@@ -239,11 +239,11 @@
       }
     },
     "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz",
-      "integrity": "sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.11.tgz",
+      "integrity": "sha512-lMnXA5KaRJidzW7gQmlo/SnX6D+AKk5GxHFcQtOaGOSJNmu/qcNZc1rGaO7K5qW52OvCLXtnWudR4cc/FvMpVQ==",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
+        "@ai-sdk/provider": "1.0.10",
         "eventsource-parser": "^3.0.0",
         "nanoid": "^3.3.8",
         "secure-json-parse": "^2.7.0"
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@ai-sdk/anthropic/node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
+      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
       "funding": [
         {
           "type": "github",
@@ -359,12 +359,12 @@
       }
     },
     "node_modules/@ai-sdk/openai": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-1.1.14.tgz",
-      "integrity": "sha512-r5oD+Sz7z8kfxnXfqR53fYQ1xbT/BeUGhQ26FWzs5gO4j52pGUpzCt0SBm3SH1ZSjFY5O/zoKRnsbrPeBe1sNA==",
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-0.0.34.tgz",
+      "integrity": "sha512-ArVGvhfp66zYqFBWS/rRL/3ushcjsDXQJ5HdcJaCbv9YCrFJzgSZwFj2tWMdBMeQn3O7SGgGsIT75zFgXJDIqQ==",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "@ai-sdk/provider-utils": "2.1.10"
+        "@ai-sdk/provider": "0.0.11",
+        "@ai-sdk/provider-utils": "1.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -373,57 +373,21 @@
         "zod": "^3.0.0"
       }
     },
-    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider-utils": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-2.1.10.tgz",
-      "integrity": "sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==",
+    "node_modules/@ai-sdk/openai/node_modules/@ai-sdk/provider": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.11.tgz",
+      "integrity": "sha512-VTipPQ92Moa5Ovg/nZIc8yNoIFfukZjUHZcQMduJbiUh3CLQyrBAKTEV9AwjPy8wgVxj3+GZjon0yyOJKhfp5g==",
       "dependencies": {
-        "@ai-sdk/provider": "1.0.9",
-        "eventsource-parser": "^3.0.0",
-        "nanoid": "^3.3.8",
-        "secure-json-parse": "^2.7.0"
+        "json-schema": "0.4.0"
       },
       "engines": {
         "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@ai-sdk/openai/node_modules/eventsource-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.0.tgz",
-      "integrity": "sha512-T1C0XCUimhxVQzW4zFipdx0SficT651NnkR0ZSH3yQwh+mFMdLfgjABVi4YtMTtaL4s168593DaoaRLMqryavA==",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@ai-sdk/openai/node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/@ai-sdk/provider": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.9.tgz",
-      "integrity": "sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.0.7.tgz",
+      "integrity": "sha512-q1PJEZ0qD9rVR+8JFEd01/QM++csMT5UVwYXSN2u54BrVw/D8TZLTeg2FEfKK00DgAx0UtWd8XOhhwITP9BT5g==",
       "dependencies": {
         "json-schema": "^0.4.0"
       },

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "analyze": "cross-env ANALYZE=true next build"
   },
   "dependencies": {
-    "@ai-sdk/amazon-bedrock": "1.0.7",
-    "@ai-sdk/anthropic": "^1.1.10",
-    "@ai-sdk/google": "1.0.7",
+    "@ai-sdk/amazon-bedrock": "^1.0.7",
+    "@ai-sdk/anthropic": "^1.1.15",
+    "@ai-sdk/google": "^1.0.7",
     "@ai-sdk/openai": "^0.0.34",
-    "@ai-sdk/provider": "1.0.7",
+    "@ai-sdk/provider": "^1.0.7",
     "@aws-sdk/client-bedrock-runtime": "^3.751.0",
     "@aws-sdk/client-s3": "3.338.0",
     "@aws-sdk/s3-presigned-post": "3.338.0",

--- a/src/app/api/allNewRoutingChat/route.ts
+++ b/src/app/api/allNewRoutingChat/route.ts
@@ -59,20 +59,13 @@ export async function POST(req: NextRequest, res: NextResponse) {
   } catch (error) {
     console.error('Error in route handler:', error)
 
-    let title = 'Error'
-    let message = 'An unexpected error occurred'
-
-    if (error instanceof OpenAIError) {
-      title = 'LLM Error'
-      message = error.message || 'Error connecting to the language model'
-    } else if (error instanceof Error) {
-      message = error.message
-    }
-
+    // For errors that occur before calling routeModelRequest
     return new Response(
       JSON.stringify({
-        title,
-        message,
+        title: 'LLM Error',
+        message: error instanceof Error
+          ? error.message
+          : 'An unexpected error occurred',
       }),
       {
         status: 500,

--- a/src/app/api/chat/bedrock/route.ts
+++ b/src/app/api/chat/bedrock/route.ts
@@ -25,7 +25,7 @@ export async function runBedrockChat(
 ) {
   try {
     if (!conversation) {
-      throw new Error('Conversation is missing')
+      throw new Error('Conversation is missing - please refresh the page')
     }
 
     if (
@@ -33,7 +33,7 @@ export async function runBedrockChat(
       !bedrockProvider.secretAccessKey ||
       !bedrockProvider.region
     ) {
-      throw new Error('AWS credentials are missing')
+      throw new Error('AWS credentials are missing - please refresh the page, or add credentials in the Admin Dashboard')
     }
 
     const bedrock = createAmazonBedrock({

--- a/src/app/utils/anthropic.ts
+++ b/src/app/utils/anthropic.ts
@@ -8,7 +8,6 @@ import {
 import { decryptKeyIfNeeded } from '~/utils/crypto'
 import { AnthropicModel } from '~/utils/modelProviders/types/anthropic'
 export const dynamic = 'force-dynamic'
-export const maxDuration = 60
 
 /**
  * Runs an Anthropic chat with the given conversation and API provider
@@ -23,9 +22,11 @@ export async function runAnthropicChat(
   if (!conversation) {
     throw new Error('Conversation is missing')
   }
-
   if (!anthropicProvider.apiKey) {
     throw new Error('Anthropic API key is missing')
+  }
+  if (conversation.messages.length === 0) {
+    throw new Error('Conversation messages array is empty')
   }
 
   const anthropic = createAnthropic({

--- a/src/app/utils/ollama.ts
+++ b/src/app/utils/ollama.ts
@@ -20,7 +20,7 @@ export async function runOllamaChat(
 
     // Check if provider is properly configured
     if (!ollamaProvider.baseUrl) {
-      throw new Error('Ollama server URL is not configured')
+      throw new Error('Ollama server URL is not configured. Set it up in the Admin Dashboard, or use a different LLM.')
     }
 
     try {
@@ -72,11 +72,10 @@ export async function runOllamaChat(
     }
   } catch (error) {
     console.error('Error in runOllamaChat:', error)
+    // return error
     return new Response(
       JSON.stringify({
         error: error instanceof Error ? error.message : 'Unknown error occurred when running Ollama',
-        detailed_error: error instanceof Error ? error.toString() : 'Unknown error',
-        source: 'Ollama',
       }),
       {
         status: 500,

--- a/src/app/utils/ollama.ts
+++ b/src/app/utils/ollama.ts
@@ -13,39 +13,76 @@ export async function runOllamaChat(
   ollamaProvider: OllamaProvider | NCSAHostedProvider,
   stream: boolean,
 ) {
-  if (!ollamaProvider.baseUrl || ollamaProvider.baseUrl === '') {
-    ollamaProvider.baseUrl = process.env.OLLAMA_SERVER_URL
-  }
+  try {
+    if (!ollamaProvider.baseUrl || ollamaProvider.baseUrl === '') {
+      ollamaProvider.baseUrl = process.env.OLLAMA_SERVER_URL
+    }
 
-  const ollama = createOllama({
-    baseURL: `${(await decryptKeyIfNeeded(ollamaProvider.baseUrl!)) as string}/api`,
-  })
+    // Check if provider is properly configured
+    if (!ollamaProvider.baseUrl) {
+      throw new Error('Ollama server URL is not configured')
+    }
 
-  if (conversation.messages.length === 0) {
-    throw new Error('Conversation messages array is empty')
-  }
+    try {
+      const ollama = createOllama({
+        baseURL: `${(await decryptKeyIfNeeded(ollamaProvider.baseUrl!)) as string}/api`,
+      })
 
-  const ollamaModel = ollama(conversation.model.id, {
-    numCtx: conversation.model.tokenLimit,
-  })
-  const commonParams = {
-    model: ollamaModel as any, // Force type compatibility
-    messages: convertConversatonToVercelAISDKv3(conversation),
-    temperature: conversation.temperature,
-    maxTokens: 4096, // output tokens
-  }
+      if (conversation.messages.length === 0) {
+        throw new Error('Conversation messages array is empty')
+      }
 
-  if (stream) {
-    const result = await streamText(commonParams)
-    return result.toTextStreamResponse()
-  } else {
-    const result = await generateText(commonParams)
-    const choices = [{ message: { content: result.text } }]
-    const response = { choices: choices }
-    return NextResponse.json(response, {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    })
+      const ollamaModel = ollama(conversation.model.id, {
+        numCtx: conversation.model.tokenLimit,
+      })
+      const commonParams = {
+        model: ollamaModel as any, // Force type compatibility
+        messages: convertConversatonToVercelAISDKv3(conversation),
+        temperature: conversation.temperature,
+        maxTokens: 4096, // output tokens
+      }
+
+      if (stream) {
+        const result = await streamText(commonParams)
+        return result.toTextStreamResponse()
+      } else {
+        const result = await generateText(commonParams)
+        const choices = [{ message: { content: result.text } }]
+        const response = { choices: choices }
+        return NextResponse.json(response, {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      }
+    } catch (apiError) {
+      console.error('Ollama API error:', apiError)
+
+      // Handle specific API errors
+      if (apiError instanceof Error) {
+        if (apiError.message.includes('timeout') || apiError.message.includes('ECONNREFUSED') || apiError.message.includes('ECONNRESET')) {
+          throw new Error(`Ollama server connection failed: ${apiError.message}. Please check if the Ollama server is running.`)
+        } else if (apiError.message.includes('not found') || apiError.message.includes('404')) {
+          throw new Error(`Ollama model '${conversation.model.id}' not found on server. Please check if the model is installed.`)
+        } else {
+          throw apiError // rethrow with original context
+        }
+      } else {
+        throw new Error('Unknown error when connecting to Ollama')
+      }
+    }
+  } catch (error) {
+    console.error('Error in runOllamaChat:', error)
+    return new Response(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error occurred when running Ollama',
+        detailed_error: error instanceof Error ? error.toString() : 'Unknown error',
+        source: 'Ollama',
+      }),
+      {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    )
   }
 }
 

--- a/src/app/utils/vllm.ts
+++ b/src/app/utils/vllm.ts
@@ -2,7 +2,6 @@ import { type CoreMessage, generateText, streamText } from 'ai'
 import { type Conversation } from '~/types/chat'
 import { type NCSAHostedVLMProvider } from '~/utils/modelProviders/LLMProvider'
 export const dynamic = 'force-dynamic'
-export const maxDuration = 60
 
 import { createOpenAI } from '@ai-sdk/openai'
 
@@ -11,38 +10,64 @@ export async function runVLLM(
   ncsaHostedVLMProvider: NCSAHostedVLMProvider,
   stream: boolean,
 ) {
-  if (!conversation) {
-    throw new Error('Conversation is missing')
-  }
+  try {
+    if (!conversation) {
+      throw new Error('Conversation is missing')
+    }
 
-  const vlmModel = createOpenAI({
-    baseURL: process.env.NCSA_HOSTED_VLM_BASE_URL,
-    apiKey: 'non-empty',
-    compatibility: 'compatible', // strict/compatible - enable 'strict' when using the OpenAI API
-  })
-  if (conversation.messages.length === 0) {
-    throw new Error('Conversation messages array is empty')
-  }
+    const vlmModel = createOpenAI({
+      baseURL: process.env.NCSA_HOSTED_VLM_BASE_URL,
+      apiKey: 'non-empty',
+      compatibility: 'compatible', // strict/compatible - enable 'strict' when using the OpenAI API
+    })
+    if (conversation.messages.length === 0) {
+      throw new Error('Conversation messages array is empty')
+    }
 
-  const model = vlmModel(conversation.model.id)
+    const model = vlmModel(conversation.model.id)
 
-  const commonParams = {
-    model: model,
-    messages: convertConversationToVercelAISDKv3(conversation),
-    temperature: conversation.temperature,
-    maxTokens: 8192,
-  }
+    const commonParams = {
+      model: model,
+      messages: convertConversationToVercelAISDKv3(conversation),
+      temperature: conversation.temperature,
+      maxTokens: 8192,
+    }
 
-  if (stream) {
-    const result = await streamText(commonParams as any)
-    return result.toTextStreamResponse()
-  } else {
-    const result = await generateText(commonParams as any)
+    try {
+      if (stream) {
+        const result = await streamText(commonParams as any)
+        return result.toTextStreamResponse()
+      } else {
+        const result = await generateText(commonParams as any)
+        return new Response(
+          JSON.stringify({ choices: [{ message: { content: result.text } }] }),
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        )
+      }
+    } catch (error) {
+      console.error('VLLM API error:', error)
+      if (error instanceof Error && error.message.includes('timeout')) {
+        throw new Error(`VLLM request timed out: ${error.message}`)
+      } else if (error instanceof Error && error.message.includes('apiKey')) {
+        throw new Error(`VLLM authentication error: Please check API configuration`)
+      } else {
+        throw error // rethrow the original error with context
+      }
+    }
+  } catch (error) {
+    console.error('Error in runVLLM:', error)
     return new Response(
-      JSON.stringify({ choices: [{ message: { content: result.text } }] }),
+      JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error occurred when running VLLM',
+        detailed_error: error instanceof Error ? error.toString() : 'Unknown error',
+        source: 'VLLM',
+      }),
       {
+        status: 500,
         headers: { 'Content-Type': 'application/json' },
-      },
+      }
     )
   }
 }

--- a/src/components/Chat/Chat.tsx
+++ b/src/components/Chat/Chat.tsx
@@ -336,8 +336,8 @@ export const Chat = memo(
             message.contexts = []
             message.content = Array.isArray(message.content)
               ? message.content.filter(
-                  (content) => content.type !== 'tool_image_url',
-                )
+                (content) => content.type !== 'tool_image_url',
+              )
               : message.content
 
             const updatedMessages = [...(selectedConversation.messages || [])]
@@ -540,12 +540,12 @@ export const Chat = memo(
                         .map((msg) => {
                           const contentText = Array.isArray(msg.content)
                             ? msg.content
-                                .filter(
-                                  (content) =>
-                                    content.type === 'text' && content.text,
-                                )
-                                .map((content) => content.text!)
-                                .join(' ')
+                              .filter(
+                                (content) =>
+                                  content.type === 'text' && content.text,
+                              )
+                              .map((content) => content.text!)
+                              .join(' ')
                             : typeof msg.content === 'string'
                               ? msg.content
                               : ''
@@ -560,12 +560,12 @@ export const Chat = memo(
                         .map((msg) => {
                           const contentText = Array.isArray(msg.content)
                             ? msg.content
-                                .filter(
-                                  (content) =>
-                                    content.type === 'text' && content.text,
-                                )
-                                .map((content) => content.text!)
-                                .join(' ')
+                              .filter(
+                                (content) =>
+                                  content.type === 'text' && content.text,
+                              )
+                              .map((content) => content.text!)
+                              .join(' ')
                             : typeof msg.content === 'string'
                               ? msg.content
                               : ''
@@ -597,9 +597,9 @@ export const Chat = memo(
                           ? msg.content.trim()
                           : Array.isArray(msg.content)
                             ? msg.content
-                                .map((c) => c.text)
-                                .join(' ')
-                                .trim()
+                              .map((c) => c.text)
+                              .join(' ')
+                              .trim()
                             : '',
                     })),
                   },
@@ -721,7 +721,7 @@ export const Chat = memo(
                   // Check if the response is NO_REWRITE_REQUIRED or if we couldn't extract a valid query
                   if (
                     rewrittenQuery.trim().toUpperCase() ===
-                      'NO_REWRITE_REQUIRED' ||
+                    'NO_REWRITE_REQUIRED' ||
                     !extractedQuery
                   ) {
                     console.log(
@@ -868,7 +868,7 @@ export const Chat = memo(
             }
           } else {
             try {
-              // CALL OUR NEW ENDPOINT... /api/chat
+              // CALL OUR NEW ENDPOINT... /api/allNewRoutingChat
               startOfCallToLLM = performance.now()
               try {
                 response = await fetch('/api/allNewRoutingChat', {
@@ -878,89 +878,55 @@ export const Chat = memo(
                   },
                   body: JSON.stringify(finalChatBody),
                 })
-                console.log('response from /api/chat', response)
+                console.debug('response from /api/chat', response)
 
                 // Check if response is ok before proceeding
                 if (!response.ok) {
                   const errorData = await response.json()
-                  throw new Error(
-                    errorData.error || 'Failed to get response from the server',
-                  )
+                  // Create a custom error object with both title and message
+                  const customError = new Error(errorData.message || 'Failed to get response from the server')
+                    // Attach the title as a property to the error object
+                    ; (customError as any).title = errorData.title || 'Error'
+                  throw customError
                 }
               } catch (error) {
-                // TODO: Improve error messages here...
-                console.error('Error routing to model provider:', error)
-                errorToast({
-                  title: 'Error routing to model provider',
-                  message:
-                    (error as Error).message || 'An unexpected error occurred',
-                })
+                console.error('Error calling the LLM:', error)
                 homeDispatch({ field: 'loading', value: false })
                 homeDispatch({ field: 'messageIsStreaming', value: false })
+
+                errorToast({
+                  title: (error as any).title || 'Error',
+                  message: error instanceof Error ? error.message : 'An unexpected error occurred',
+                })
                 return
               }
             } catch (error) {
-              // TODO: Improve error messages here...
-              console.error('Error routing to model provider:', error)
-              errorToast({
-                title: 'Error routing to model provider',
-                message:
-                  (error as Error).message || 'An unexpected error occurred',
-              })
+              console.error('Error in chat handler:', error)
               homeDispatch({ field: 'loading', value: false })
               homeDispatch({ field: 'messageIsStreaming', value: false })
+
+              errorToast({
+                title: (error as any).title || 'Error',
+                message: error instanceof Error ? error.message : 'An unexpected error occurred',
+              })
               return
             }
           }
 
           if (response instanceof Response && !response.ok) {
-            let final_response
-            try {
-              final_response = await response.json()
-            } catch (error) {
-              console.error('Error parsing response:', error)
-              homeDispatch({ field: 'loading', value: false })
-              homeDispatch({ field: 'messageIsStreaming', value: false })
-              errorToast({
-                title: 'Error',
-                message:
-                  'Received an invalid response from the server. Please try again.',
-              })
-              return
-            }
-
             homeDispatch({ field: 'loading', value: false })
             homeDispatch({ field: 'messageIsStreaming', value: false })
-            console.error('Error calling the LLM:', final_response)
 
-            if (final_response.error) {
-              let errorMessage = final_response.error
-              let errorCode = final_response.code
-
-              // Handle case where error is a JSON string
-              if (typeof final_response.error === 'string') {
-                try {
-                  const parsed = JSON.parse(final_response.error)
-                  errorMessage = parsed.error || parsed.message
-                  errorCode = parsed.code
-                } catch (e) {
-                  // Keep original error message if not valid JSON
-                }
-              }
-
+            try {
+              const errorData = await response.json()
               errorToast({
-                title: `Error calling LLM`,
-                message:
-                  errorMessage ||
-                  `An unexpected error occurred. Try using a different model.${errorCode ? ` Error code: ${errorCode}` : ''}`,
+                title: errorData.title || 'Error',
+                message: errorData.message || 'There was an unexpected error calling the LLM. Try using a different model.',
               })
-              return
-            } else {
+            } catch (error) {
               errorToast({
-                title: final_response.name || 'Error',
-                message:
-                  final_response.message ||
-                  'There was an unexpected error calling the LLM. Try using a different model (via the Settings button in the header).',
+                title: 'Error',
+                message: 'There was an unexpected error calling the LLM. Try using a different model.',
               })
             }
             return
@@ -1578,13 +1544,13 @@ export const Chat = memo(
 
     const statements =
       courseMetadata?.example_questions &&
-      courseMetadata.example_questions.length > 0
+        courseMetadata.example_questions.length > 0
         ? courseMetadata.example_questions
         : [
-            'Make a bullet point list of key takeaways from this project.',
-            'What are the best practices for [Activity or Process] in [Context or Field]?',
-            'Can you explain the concept of [Specific Concept] in simple terms?',
-          ]
+          'Make a bullet point list of key takeaways from this project.',
+          'What are the best practices for [Activity or Process] in [Context or Field]?',
+          'Can you explain the concept of [Specific Concept] in simple terms?',
+        ]
 
     // Add this function to create dividers with statements
     const renderIntroductoryStatements = () => {
@@ -1899,8 +1865,8 @@ export const Chat = memo(
                     transition={{ duration: 0.1 }}
                   >
                     {selectedConversation &&
-                    selectedConversation.messages &&
-                    selectedConversation.messages?.length === 0 ? (
+                      selectedConversation.messages &&
+                      selectedConversation.messages?.length === 0 ? (
                       <>
                         <div className="mt-16">
                           {renderIntroductoryStatements()}
@@ -1918,7 +1884,7 @@ export const Chat = memo(
                                 handleSend(
                                   editedMessage,
                                   selectedConversation?.messages?.length -
-                                    index,
+                                  index,
                                   null,
                                   tools,
                                   enabledDocumentGroups,

--- a/src/components/Chat/ChatInput.tsx
+++ b/src/components/Chat/ChatInput.tsx
@@ -193,10 +193,7 @@ export const ChatInput = ({
 
     if (maxLength && value.length > maxLength) {
       alert(
-        t(
-          `Message limit is {{maxLength}} characters. You have entered {{valueLength}} characters.`,
-          { maxLength, valueLength: value.length },
-        ),
+        `This LLM can only handle ${maxLength} characters, but you entered ${value.length} characters. Please switch to a model with a bigger input limit (like Gemini, Claude or GPT) or shorten your message.`,
       )
       return
     }
@@ -224,10 +221,10 @@ export const ChatInput = ({
           imageUrls.length > 0
             ? imageUrls
             : await Promise.all(
-                imageFiles.map((file) =>
-                  uploadImageAndGetUrl(file, courseName),
-                ),
-              )
+              imageFiles.map((file) =>
+                uploadImageAndGetUrl(file, courseName),
+              ),
+            )
 
         // Construct image content for the message
         imageContent = imageUrlsToUse
@@ -684,9 +681,8 @@ export const ChatInput = ({
     if (textareaRef && textareaRef.current) {
       textareaRef.current.style.height = 'inherit'
       textareaRef.current.style.height = `${textareaRef.current?.scrollHeight}px`
-      textareaRef.current.style.overflow = `${
-        textareaRef?.current?.scrollHeight > 400 ? 'auto' : 'hidden'
-      }`
+      textareaRef.current.style.overflow = `${textareaRef?.current?.scrollHeight > 400 ? 'auto' : 'hidden'
+        }`
     }
   }, [content])
 
@@ -968,20 +964,18 @@ export const ChatInput = ({
             {/* Button 3: main input text area  */}
             <div
               className={`
-                ${
-                  VisionCapableModels.has(
-                    selectedConversation?.model?.id as OpenAIModelID,
-                  )
-                    ? 'pl-8'
-                    : 'pl-1'
+                ${VisionCapableModels.has(
+                selectedConversation?.model?.id as OpenAIModelID,
+              )
+                  ? 'pl-8'
+                  : 'pl-1'
                 }
                   `}
             >
               <textarea
                 ref={textareaRef}
-                className={`chat-input m-0 h-[24px] max-h-[400px] w-full resize-none bg-transparent py-2 pl-2 pr-8 text-white outline-none ${
-                  isFocused ? 'border-blue-500' : ''
-                }`}
+                className={`chat-input m-0 h-[24px] max-h-[400px] w-full resize-none bg-transparent py-2 pl-2 pr-8 text-white outline-none ${isFocused ? 'border-blue-500' : ''
+                  }`}
                 style={{
                   resize: 'none',
                   minHeight: '24px',

--- a/src/pages/api/UIUC-api/MIGRATEALLKEYS.ts
+++ b/src/pages/api/UIUC-api/MIGRATEALLKEYS.ts
@@ -11,7 +11,6 @@ import { encryptKeyIfNeeded } from '~/utils/crypto'
 import { redisClient } from '~/utils/redisClient'
 
 export const runtime = 'edge'
-export const maxDuration = 60
 
 export default async function handler(
   req: NextRequest,

--- a/src/pages/api/chat-api/chat.ts
+++ b/src/pages/api/chat-api/chat.ts
@@ -40,7 +40,6 @@ import {
 import { buildPrompt } from '~/app/utils/buildPromptUtils'
 import { selectBestTemperature } from '~/components/Chat/Temperature'
 
-export const maxDuration = 60
 /**
  * The chat API endpoint for handling chat requests and streaming/non streaming responses.
  * This function orchestrates the validation of the request, user permissions,
@@ -217,7 +216,7 @@ export default async function chat(
     prompt:
       messages.filter((message) => message.role === 'system').length > 0
         ? ((messages.filter((message) => message.role === 'system')[0]
-            ?.content as string) ??
+          ?.content as string) ??
           (messages.filter((message) => message.role === 'system')[0]
             ?.content as string))
         : DEFAULT_SYSTEM_PROMPT,
@@ -230,8 +229,8 @@ export default async function chat(
   // Check if the content is an array and filter out image content
   const imageContent = Array.isArray(lastMessage.content)
     ? (lastMessage.content as Content[]).filter(
-        (content) => content.type === 'image_url',
-      )
+      (content) => content.type === 'image_url',
+    )
     : []
 
   const imageUrls = imageContent.map(

--- a/src/utils/modelProviders/OpenAIAzureChat.ts
+++ b/src/utils/modelProviders/OpenAIAzureChat.ts
@@ -1,9 +1,6 @@
-import { initializeEncoding } from '@/utils/encoding'
 import { OpenAIError, OpenAIStream } from '@/utils/server'
 import { ChatBody, Message } from '@/types/chat'
-import { NextApiRequest, NextApiResponse } from 'next'
 
-export const maxDuration = 60
 
 export const openAIAzureChat = async (
   chatBody: ChatBody,

--- a/src/utils/modelProviders/routes/sambanova.ts
+++ b/src/utils/modelProviders/routes/sambanova.ts
@@ -14,7 +14,7 @@ export async function getSambaNovaModels(
     delete provider.error // Clear any previous errors
 
     // If provider is disabled, return early with empty models
-    if (!provider.enabled) {
+    if (!provider.enabled || !provider.apiKey) {
       return {
         ...provider,
         models: [],

--- a/src/utils/streamProcessing.ts
+++ b/src/utils/streamProcessing.ts
@@ -781,182 +781,90 @@ export const routeModelRequest = async (
 
   console.debug('In routeModelRequest: ', chatBody, baseUrl)
 
-  try {
-    const selectedConversation = chatBody.conversation!
-    console.debug('Selected conversation:', selectedConversation)
-    if (!selectedConversation.model || !selectedConversation.model.id) {
-      console.debug('Invalid conversation:', selectedConversation)
-      throw new Error('Conversation model is undefined or missing "id" property.')
-    }
+  const selectedConversation = chatBody.conversation!
+  console.debug('Selected conversation:', selectedConversation)
+  if (!selectedConversation.model || !selectedConversation.model.id) {
+    console.debug('Invalid conversation:', selectedConversation)
+    throw new Error('Conversation model is undefined or missing "id" property.')
+  }
 
-    posthog.capture('LLM Invoked', {
-      distinct_id: selectedConversation.userEmail
-        ? selectedConversation.userEmail
-        : 'anonymous',
-      user_id: selectedConversation.userEmail
-        ? selectedConversation.userEmail
-        : 'anonymous',
-      conversation_id: selectedConversation.id,
-      model_id: selectedConversation.model.id,
-    })
+  posthog.capture('LLM Invoked', {
+    distinct_id: selectedConversation.userEmail
+      ? selectedConversation.userEmail
+      : 'anonymous',
+    user_id: selectedConversation.userEmail
+      ? selectedConversation.userEmail
+      : 'anonymous',
+    conversation_id: selectedConversation.id,
+    model_id: selectedConversation.model.id,
+  })
 
-    if (
-      Object.values(NCSAHostedVLMModelID).includes(
-        selectedConversation.model.id as any,
-      )
-    ) {
-      // NCSA Hosted VLM - already has error handling internally
-      return await runVLLM(
-        selectedConversation,
-        chatBody?.llmProviders?.NCSAHostedVLM as NCSAHostedVLMProvider,
-        chatBody.stream,
-      )
-    } else if (
-      Object.values(OllamaModelIDs).includes(selectedConversation.model.id as any)
-    ) {
-      // Ollama - already has error handling internally
-      return await runOllamaChat(
-        selectedConversation,
-        chatBody!.llmProviders!.Ollama as OllamaProvider,
-        chatBody.stream,
-      )
-    } else if (
-      Object.values(AnthropicModelID).includes(
-        selectedConversation.model.id as any,
-      )
-    ) {
-      try {
-        return await runAnthropicChat(
-          selectedConversation,
-          chatBody.llmProviders?.Anthropic as AnthropicProvider,
-          chatBody.stream,
-        )
-      } catch (error) {
-        return new Response(
-          JSON.stringify({
-            title: 'Anthropic Error',
-            message: error instanceof Error
-              ? error.message
-              : 'Unknown error occurred when streaming Anthropic LLMs.',
-          }),
-          {
-            status: 500,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        )
-      }
-    } else if (
-      Object.values(OpenAIModelID).includes(
-        selectedConversation.model.id as any,
-      ) ||
-      Object.values(AzureModelID).includes(selectedConversation.model.id as any)
-    ) {
-      try {
-        return await openAIAzureChat(chatBody, chatBody.stream)
-      } catch (error) {
-        console.error('OpenAI/Azure API error:', error)
-        return new Response(
-          JSON.stringify({
-            title: 'OpenAI/Azure Error',
-            message: error instanceof Error
-              ? error.message
-              : 'Unknown error occurred when streaming OpenAI/Azure LLMs.',
-          }),
-          {
-            status: 500,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        )
-      }
-    } else if (
-      Object.values(BedrockModelID).includes(selectedConversation.model.id as any)
-    ) {
-      try {
-        return await runBedrockChat(
-          selectedConversation,
-          chatBody.llmProviders?.Bedrock as BedrockProvider,
-          chatBody.stream,
-        )
-      } catch (error) {
-        return new Response(
-          JSON.stringify({
-            title: 'Bedrock Error',
-            message: error instanceof Error
-              ? error.message
-              : 'Unknown error occurred when streaming Bedrock LLMs.',
-          }),
-          {
-            status: 500,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        )
-      }
-    } else if (
-      Object.values(GeminiModelID).includes(selectedConversation.model.id as any)
-    ) {
-      try {
-        return await runGeminiChat(
-          selectedConversation,
-          chatBody.llmProviders?.Gemini as GeminiProvider,
-          chatBody.stream,
-        )
-      } catch (error) {
-        return new Response(
-          JSON.stringify({
-            title: 'Gemini Error',
-            message: error instanceof Error
-              ? error.message
-              : 'Unknown error occurred when streaming Gemini LLMs.',
-          }),
-          {
-            status: 500,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        )
-      }
-    } else if (
-      Object.values(SambaNovaModelID).includes(
-        selectedConversation.model.id as any,
-      )
-    ) {
-      try {
-        return await runSambaNovaChat(
-          selectedConversation,
-          chatBody.llmProviders?.SambaNova as SambaNovaProvider,
-          chatBody.stream,
-        )
-      } catch (error) {
-        return new Response(
-          JSON.stringify({
-            title: 'SambaNova Error',
-            message: error instanceof Error
-              ? error.message
-              : 'Unknown error occurred when streaming SambaNova LLMs.',
-          }),
-          {
-            status: 500,
-            headers: { 'Content-Type': 'application/json' },
-          },
-        )
-      }
-    } else {
-      throw new Error(
-        `Model '${selectedConversation.model.name}' is not supported.`,
-      )
-    }
-  } catch (error) {
-    console.error('General error in routeModelRequest:', error)
-    return new Response(
-      JSON.stringify({
-        title: 'Model Error',
-        message: error instanceof Error
-          ? error.message
-          : 'An unexpected error occurred in model routing',
-      }),
-      {
-        status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      },
+  if (
+    Object.values(NCSAHostedVLMModelID).includes(
+      selectedConversation.model.id as any,
+    )
+  ) {
+    // NCSA Hosted VLM
+    return await runVLLM(
+      selectedConversation,
+      chatBody?.llmProviders?.NCSAHostedVLM as NCSAHostedVLMProvider,
+      chatBody.stream,
+    )
+  } else if (
+    Object.values(OllamaModelIDs).includes(selectedConversation.model.id as any)
+  ) {
+    // Ollama
+    return await runOllamaChat(
+      selectedConversation,
+      chatBody!.llmProviders!.Ollama as OllamaProvider,
+      chatBody.stream,
+    )
+  } else if (
+    Object.values(AnthropicModelID).includes(
+      selectedConversation.model.id as any,
+    )
+  ) {
+    return await runAnthropicChat(
+      selectedConversation,
+      chatBody.llmProviders?.Anthropic as AnthropicProvider,
+      chatBody.stream,
+    )
+  } else if (
+    Object.values(OpenAIModelID).includes(
+      selectedConversation.model.id as any,
+    ) ||
+    Object.values(AzureModelID).includes(selectedConversation.model.id as any)
+  ) {
+    return await openAIAzureChat(chatBody, chatBody.stream)
+  } else if (
+    Object.values(BedrockModelID).includes(selectedConversation.model.id as any)
+  ) {
+    return await runBedrockChat(
+      selectedConversation,
+      chatBody.llmProviders?.Bedrock as BedrockProvider,
+      chatBody.stream,
+    )
+  } else if (
+    Object.values(GeminiModelID).includes(selectedConversation.model.id as any)
+  ) {
+    return await runGeminiChat(
+      selectedConversation,
+      chatBody.llmProviders?.Gemini as GeminiProvider,
+      chatBody.stream,
+    )
+  } else if (
+    Object.values(SambaNovaModelID).includes(
+      selectedConversation.model.id as any,
+    )
+  ) {
+    return await runSambaNovaChat(
+      selectedConversation,
+      chatBody.llmProviders?.SambaNova as SambaNovaProvider,
+      chatBody.stream,
+    )
+  } else {
+    throw new Error(
+      `Model '${selectedConversation.model.name}' is not supported.`,
     )
   }
 }


### PR DESCRIPTION
Main files changed: 

Ensure errors are propegated fully through this chain. I simplified it a lot, removed most try-catch blocks. So the errors flow freely without being caught and transformed every step of the way. 
`Chat.tsx -> allNewRoutingChat -> streamProcessing -> LLM (Gemini, OpenAI, etc).`

Also fixed Sambanovel models showing up when no API key was entered. 

Also fixed bug where if you sent a message within ~1 second, the `LLMProviders` are not loaded yet, causing weird error message about `undefined`. Now it'll fetch it again if it's undefined. 